### PR TITLE
i18n(cs): Add Czech translation

### DIFF
--- a/i18n/cs/cedilla.ftl
+++ b/i18n/cs/cedilla.ftl
@@ -1,0 +1,77 @@
+<#-- General -->
+loading = Načítání
+create = Vytvořit
+cancel = Zrušit
+delete = Smazat
+rename = Přejmenovat
+move = Přesunout
+move-to = Přesunout do
+name = Název
+
+<#-- About Page -->
+repository = Repozitář
+support = Podpora
+
+<#-- Main App -->
+editor = Editor
+preview = Náhled
+file-name = Název souboru
+folder-name = Název složky
+delete-node = Smazat soubor/složku
+delete-confirmation = Opravdu chcete smazat tento soubor/složku a jeho obsah?
+save-changes-closing = Uložit změny před zavřením?
+save-warning = Máte neuložené změny. Pokud se rozhodnete pokračovat bez uložení, změny budou ztraceny.
+discard-changes = Zahodit změny
+
+<#-- Appearance -->
+appearance = Vzhled
+theme = Motiv
+match-desktop = Podle systému
+dark = Tmavý
+light = Světlý
+
+<#-- Settings Context Page -->
+general = Obecné
+help-bar = Lišta nápovědy editoru
+status-bar = Stavová lišta
+move-vault = Přesunout trezor
+current-location = Aktuální umístění: { $location }
+show = Zobrazit
+hide = Skrýt
+last-file = Otevřít poslední soubor při spuštění aplikace
+yes = Ano
+no = Ne
+scrollbar-sync = Synchronizovat posuvníky náhledu a editoru
+pdf-exporting = Export do PDF
+gotenberg-url = Nastavit URL serveru Gotenberg
+apply = Použít
+more-info = Více informací
+text-size = Velikost textu
+
+<#-- Application MenuBar -->
+file = Soubor
+new-vault-file = Nový soubor trezoru
+new-folder = Nová složka
+open-file = Otevřít soubor
+save-file = Uložit soubor
+new-file = Nový soubor
+
+edit = Úpravy
+undo = Zpět
+redo = Znovu
+
+view = Zobrazení
+about = O aplikaci
+settings = Nastavení
+
+<#-- Helper HeaderBar -->
+bold = Tučné
+italic = Kurzíva
+link = Odkaz
+code = Kód
+image = Obrázek
+attachment = Příloha
+bullet-list = Odrážkový seznam
+numbered-list = Číslovaný seznam
+checkbox = Zaškrtávací políčko
+horizontal-rule = Horizontální čára

--- a/resources/app.desktop
+++ b/resources/app.desktop
@@ -1,6 +1,7 @@
 [Desktop Entry]
 Name=Cedilla
 Comment=A markdown text editor for the COSMIC™ desktop
+Comment[cs]=Editor textu Markdown pro prostředí COSMIC™
 Type=Application
 Icon=dev.mariinkys.Cedilla
 Exec=cedilla %F
@@ -8,3 +9,4 @@ Terminal=false
 StartupNotify=true
 Categories=COSMIC;Utility;TextTools;Office;
 Keywords=COSMIC;Markdown;MD;Editor;Text;Writing;Notes;Documentation;Markup;Preview;
+Keywords[cs]=COSMIC;Markdown;MD;Editor;Text;Psaní;Poznámky;Dokumentace;Markup;Náhled;

--- a/resources/app.metainfo.xml
+++ b/resources/app.metainfo.xml
@@ -10,6 +10,7 @@
 
   <name>Cedilla</name>
   <summary>Markdown Text Editor</summary>
+  <summary xml:lang="cs">Editor textu Markdown</summary>
 
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-only</project_license>
@@ -20,15 +21,27 @@
       distractions. Whether you're taking notes, drafting documentation, or writing blog posts,
       Cedilla provides a clean and intuitive environment for working with plain text and
       Markdown.</p>
+    <p xml:lang="cs"
+        >Cedilla je jednoduchý editor textu Markdown, navržený pro psaní bez zbytečného
+      rozptylování. Ať už si děláte poznámky, připravujete dokumentaci nebo píšete blogové příspěvky,
+      Cedilla nabízí čisté a intuitivní prostředí pro práci s prostým textem a také
+      Markdownem.</p>
     <ul>
       <li>Clean and minimal writing interface</li>
+      <li xml:lang="cs">Čisté a minimalistické uživatelské rozhraní pro psaní</li>
       <li>Live Markdown preview</li>
+      <li xml:lang="cs">Živý náhled Markdownu</li>
       <li>Fast and lightweight</li>
+      <li xml:lang="cs">Rychlý a lehký</li>
       <li>Works completely offline</li>
+      <li xml:lang="cs">Funguje zcela offline</li>
     </ul>
     <p
         >This app has been developed with libcosmic for the COSMIC™ desktop, and issues may occur on
       other platforms</p>
+    <p xml:lang="cs"
+        >Tato aplikace byla vyvinuta za pomoci libcosmic pro prostředí COSMIC™ a na jiných platformách
+      mohou nastat problémy.</p>
   </description>
 
   <icon type="remote" height="256" width="256">
@@ -42,15 +55,17 @@
   </provides>
 
   <screenshots>
-    <screenshot type="default" xml:lang="en">
+    <screenshot type="default">
       <image>
         https://raw.githubusercontent.com/mariinkys/cedilla/main/resources/screenshots/main-light.png</image>
       <caption>Main Page (Light)</caption>
+      <caption xml:lang="cs">Hlavní stránka (Světlý režim)</caption>
     </screenshot>
-    <screenshot xml:lang="en">
+    <screenshot>
       <image>
         https://raw.githubusercontent.com/mariinkys/cedilla/main/resources/screenshots/main-dark.png</image>
       <caption>Main Page (Dark)</caption>
+      <caption xml:lang="cs">Hlavní stránka (Tmavý režim)</caption>
     </screenshot>
   </screenshots>
 
@@ -87,6 +102,11 @@
     <keyword>Documentation</keyword>
     <keyword>Markup</keyword>
     <keyword>Preview</keyword>
+
+    <keyword xml:lang="cs">Psaní</keyword>
+    <keyword xml:lang="cs">Poznámky</keyword>
+    <keyword xml:lang="cs">Dokumentace</keyword>
+    <keyword xml:lang="cs">Náhled</keyword>
   </keywords>
 
   <releases>


### PR DESCRIPTION
Hi! This adds Czech translation.

There's one thing I'm not sure about.
 - In the metainfo.xml file, there are keywords
 - I picked only those that can be translated (the same terms would be used for the others)
 - I expect your app will land on Flathub someday, will it be searchable by both the localized keys and the english/generic ones ? Or should I duplicate them ?