### PR TITLE
fix(files): force URI decode to resolve 'os error 2'

### DIFF
--- a/src/app/core/utils/files.rs
+++ b/src/app/core/utils/files.rs
@@ -5,6 +5,15 @@ use cosmic::dialog::{ashpd::desktop::file_chooser::SelectedFiles, file_chooser::
 use std::{path::PathBuf, sync::Arc};
 
 pub async fn load_file(path: PathBuf) -> Result<(PathBuf, Arc<String>), anywho::Error> {
+    let path = path.to_str().and_then(|s| {
+        let url_str = if s.starts_with("file://") {
+            s.to_string()
+        } else {
+            format!("file://{}", s)
+        };
+        url::Url::parse(&url_str).ok()?.to_file_path().ok()
+    }).unwrap_or(path);
+
     let contents = tokio::fs::read_to_string(&path)
         .await
         .map(Arc::new)


### PR DESCRIPTION
When opening files via the file chooser (XDG portal), paths containing spaces (like `a a`) or non-ASCII characters (`ç, ş, ğ`) are sometimes passed without the `file://` prefix but still URL-encoded (e.g., `%20` or `%C3%A7`). 

Attempting to read these directly into a `PathBuf` throws an `os error 2` (No such file or directory). 

This patch forces a `file://` prefix if it's missing, parses it with `url::Url` to properly decode the string, and restores native file opening for custom vaults and complex paths. Tested natively on Pop!_OS and it works flawlessly.