### PR TITLE
Fix icon-svg-dst path in justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -23,7 +23,7 @@ appdata-dst := base-dir / 'share' / 'metainfo' / appdata
 bin-dst := base-dir / 'bin' / name
 desktop-dst := base-dir / 'share' / 'applications' / desktop
 icons-dst := base-dir / 'share' / 'icons' / 'hicolor'
-icon-svg-dst := icons-dst / 'scalable' / 'apps'
+icon-svg-dst := icons-dst / 'scalable' / 'apps' / icon-svg
 
 # Default recipe which runs `just build-release`
 default: build-release


### PR DESCRIPTION
In the current state, the icon is installed as a file called `apps` in `/usr/share/icons/hicolor/scalable/`.