### PR TITLE
feat(i18n): add Brazilian Portuguese (pt-BR) l10n

### DIFF
--- a/i18n/pt-BR/cedilla.ftl
+++ b/i18n/pt-BR/cedilla.ftl
@@ -1,0 +1,91 @@
+<#-- General -->
+loading = Carregando
+create = Criar
+cancel = Cancelar
+delete = Excluir
+rename = Renomear
+move = Mover
+move-to = Mover Para
+open-file-manager = Abrir Pasta
+name = Nome
+
+<#-- About Page -->
+repository = Repositório
+support = Suporte
+donations = Doações
+
+<#-- Main App -->
+editor = Editor
+preview = Pré-visualização
+file-name = Nome do Arquivo
+folder-name = Nome da Pasta
+delete-node = Excluir Arquivo/Pasta
+delete-confirmation = Tem certeza de que deseja excluir este arquivo/pasta e seu conteúdo?
+save-changes-closing = Salvar alterações antes de fechar?
+save-warning = Você tem alterações não salvas. Se continuar sem salvar, essas alterações serão perdidas.
+discard-changes = Descartar Alterações
+
+<#-- Appearance -->
+appearance = Aparência
+theme = Tema
+match-desktop = Acompanhar Sistema
+dark = Escuro
+light = Claro
+dark-highlighter = Destaque do Tema Escuro
+light-highlighter = Destaque do Tema Claro
+
+<#-- Settings Context Page -->
+general = Geral
+help-bar = Barra de Ajuda do Editor
+status-bar = Barra de Status
+move-vault = Mover Cofre
+current-location = Localização Atual:
+show = Mostrar
+hide = Ocultar
+last-file = Abrir o último arquivo ao iniciar o aplicativo
+yes = Sim
+no = Não
+scrollbar-sync = Sincronizar rolagem do Editor e da Pré-visualização
+pdf-exporting = Exportação de PDF
+gotenberg-url = Definir a URL do servidor Gotenberg
+apply = Aplicar
+more-info = Mais Informações
+text-size = Tamanho do Texto
+vault-default-location = Padrão (Diretório de Dados do Aplicativo)
+flatpak-permissions = Por padrão, a versão Flatpak tem permissões apenas para as pastas Documentos, Downloads e Imagens. Mover o cofre para qualquer outro local fará o aplicativo parar de funcionar corretamente. Se quiser usar outros diretórios, ajuste as permissões com ferramentas como o Flatseal.
+flatpak-permissions-note = Nota: isso também afeta o carregamento de imagens. Imagens locais só serão carregadas se estiverem em uma pasta com permissões.
+selected-font = Fonte Selecionada
+default-font = Fonte Padrão
+font-selection-info = Algumas fontes não funcionarão, e o aplicativo usará automaticamente a fonte padrão (sem alterar a fonte selecionada nas configurações). Isso não é um bug; é o comportamento esperado.
+
+<#-- Application MenuBar -->
+file = Arquivo
+new-vault-file = Novo Arquivo no Cofre
+new-folder = Nova Pasta
+open-file = Abrir Arquivo
+save-file = Salvar Arquivo
+new-file = Novo Arquivo
+
+edit = Editar
+undo = Desfazer
+redo = Refazer
+
+view = Visualizar
+about = Sobre
+settings = Configurações
+
+<#-- Helper HeaderBar -->
+bold = Negrito
+italic = Itálico
+link = Hiperlink
+code = Código
+image = Imagem
+attachment = Anexo
+bullet-list = Lista com Marcadores
+numbered-list = Lista Numerada
+checkbox = Caixa de Seleção
+horizontal-rule = Linha Horizontal
+
+<#-- Search -->
+search = Pesquisar
+no-results = Nenhum Resultado


### PR DESCRIPTION
Adds Brazilian Portuguese translation to Cedilla by including `pt-BR/cedilla.ftl` to `i18n/`.

`pt-BR` is used instead of `pt` since there are notable differences on pt-BR vs pt-PT for some words (Ex. "Arquivo" x "Ficheiro").

