### PR TITLE
Add basic Vim mode to the editor

### DIFF
--- a/i18n/en/cedilla.ftl
+++ b/i18n/en/cedilla.ftl
@@ -64,6 +64,13 @@ selected-font = Selected Font
 default-font = Default Font
 font-selection-info = Some fonts will not work, and the app will automatically fall back to the default font (without changing the selected font in the settings). That is not a bug; it is the intended behavior.
 
+vim-mode = Vim Mode
+toggle-vim-mode = Toggle Vim Mode
+vim-normal = NORMAL
+vim-insert = INSERT
+vim-visual = VISUAL
+vim-visual-line = VISUAL LINE
+
 <#-- Application MenuBar -->
 file = File
 new-vault-file = New Vault File

--- a/src/app.rs
+++ b/src/app.rs
@@ -35,9 +35,24 @@ use widgets::{TextEditor, text_editor};
 
 pub mod app_menu;
 mod context_page;
-mod core;
+pub mod core;
 mod dialogs;
 mod update;
+
+pub use core::vim::VimMode;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VimAction {
+    SetMode(VimMode),
+    Escape,
+    GoToTop,
+    GoToBottom,
+    VisualGoToTop,
+    VisualGoToBottom,
+    YankLine,
+    DeleteLine,
+    Paste { before: bool },
+}
 
 const REPOSITORY: &str = env!("CARGO_PKG_REPOSITORY");
 
@@ -193,6 +208,10 @@ pub enum Message {
     Search(SearchAction),
     /// Smart paste (pastes images as Markdown or standard text)
     SmartPaste,
+    /// Vim mode related action
+    Vim(VimAction),
+    /// Toggle Vim Mode
+    ToggleVimMode,
 
     /// Update the HTML renderer state
     UpdateMarkState(UpdateMsg),
@@ -359,7 +378,8 @@ impl cosmic::Application for AppModel {
 
     /// Elements to pack at the start of the header bar.
     fn header_start(&self) -> Vec<Element<'_, Self::Message>> {
-        vec![app_menu::menu_bar(&self.key_binds)]
+        let is_vim = self.config.vim_mode == BoolState::Yes;
+        vec![app_menu::menu_bar(&self.key_binds, is_vim)]
     }
 
     /// Elements to pack at the end of the header bar.
@@ -759,6 +779,8 @@ impl cosmic::Application for AppModel {
             Message::Redo => self.handle_redo(),
             Message::Search(action) => self.handle_search(action),
             Message::SmartPaste => self.handle_smart_paste(),
+            Message::Vim(action) => self.handle_vim_action(action),
+            Message::ToggleVimMode => self.handle_toggle_vim_mode(),
 
             // Preview / Pane
             Message::UpdateMarkState(msg) => self.handle_update_mark_state(msg),
@@ -956,6 +978,17 @@ impl AppModel {
                     ),
                 )
                 .add(
+                    widget::settings::item::builder(fl!("vim-mode")).control(widget::dropdown(
+                        BoolState::all_labels(),
+                        Some(self.config.vim_mode.to_index()),
+                        |index| {
+                            Message::ConfigInput(ConfigInput::VimMode(
+                                BoolState::from_index(index),
+                            ))
+                        },
+                    )),
+                )
+                .add(
                     cosmic::widget::column::with_children(vec![
                         column![
                             text::body(fl!("pdf-exporting")),
@@ -1037,9 +1070,18 @@ fn cedilla_main_view<'a>(
                 }
             };
 
+            let is_vim = app_config.vim_mode == BoolState::Yes;
+            let is_block_cursor = is_vim
+                && matches!(
+                    editor.vim.mode,
+                    VimMode::Normal | VimMode::Visual | VimMode::VisualLine
+                );
+            let vim_state = std::cell::RefCell::new(editor.vim.clone());
+
             scrollable(
                 TextEditor::new(&editor.content)
                     .id(text_editor_id())
+                    .block_cursor(is_block_cursor)
                     .highlight_with::<highlighter::Highlighter>(
                         highlighter::Settings {
                             theme: highlighter_theme,
@@ -1052,7 +1094,16 @@ fn cedilla_main_view<'a>(
                         },
                         |highlight, _theme| highlight.to_format(),
                     )
-                    .key_binding(text_editor_key_bindings)
+                    .key_binding(move |key_press| {
+                        if is_vim {
+                            if let Some(binding) =
+                                core::vim::handle_vim_key_press(&mut vim_state.borrow_mut(), &key_press)
+                            {
+                                return Some(binding);
+                            }
+                        }
+                        text_editor_key_bindings(key_press)
+                    })
                     .size(app_config.text_size)
                     .font(font)
                     .padding(0)
@@ -1198,8 +1249,20 @@ fn cedilla_main_view<'a>(
             .size(12)
         };
 
+        let vim_indicator = if app_config.vim_mode == BoolState::Yes {
+            let mode_label = match editor.vim.mode {
+                VimMode::Normal => fl!("vim-normal"),
+                VimMode::Insert => fl!("vim-insert"),
+                VimMode::Visual => fl!("vim-visual"),
+                VimMode::VisualLine => fl!("vim-visual-line"),
+            };
+            text(format!("-- {mode_label} --")).size(12)
+        } else {
+            text("").size(12)
+        };
+
         container(
-            row![file_path, dirty_indicator, horizontal(), position]
+            row![file_path, dirty_indicator, horizontal(), vim_indicator, horizontal(), position]
                 .padding(spacing.space_xxs)
                 .spacing(spacing.space_xxs),
         )

--- a/src/app.rs
+++ b/src/app.rs
@@ -1080,12 +1080,14 @@ fn cedilla_main_view<'a>(
                     editor.vim.mode,
                     VimMode::Normal | VimMode::Visual | VimMode::VisualLine
                 );
+            let enable_ime = !is_vim || editor.vim.mode == VimMode::Insert;
             let vim_state = editor.vim.clone();
 
             scrollable(
                 TextEditor::new(&editor.content)
                     .id(text_editor_id())
                     .block_cursor(is_block_cursor)
+                    .enable_input_method(enable_ime)
                     .highlight_with::<highlighter::Highlighter>(
                         highlighter::Settings {
                             theme: highlighter_theme,

--- a/src/app.rs
+++ b/src/app.rs
@@ -39,11 +39,15 @@ pub mod core;
 mod dialogs;
 mod update;
 
-pub use core::vim::VimMode;
+pub use core::vim::{VimMode, VimPendingOperator};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VimAction {
     SetMode(VimMode),
+    SetPendingOperator(Option<VimPendingOperator>),
+    SetCountPrefix(Option<usize>),
+    ResetOperatorAndCount,
+    VisualYank { is_line: bool },
     Escape,
     GoToTop,
     GoToBottom,
@@ -1076,7 +1080,7 @@ fn cedilla_main_view<'a>(
                     editor.vim.mode,
                     VimMode::Normal | VimMode::Visual | VimMode::VisualLine
                 );
-            let vim_state = std::cell::RefCell::new(editor.vim.clone());
+            let vim_state = editor.vim.clone();
 
             scrollable(
                 TextEditor::new(&editor.content)
@@ -1095,12 +1099,11 @@ fn cedilla_main_view<'a>(
                         |highlight, _theme| highlight.to_format(),
                     )
                     .key_binding(move |key_press| {
-                        if is_vim {
-                            if let Some(binding) =
-                                core::vim::handle_vim_key_press(&mut vim_state.borrow_mut(), &key_press)
-                            {
-                                return Some(binding);
-                            }
+                        if is_vim
+                            && let Some(binding) =
+                                core::vim::handle_vim_key_press(&vim_state, &key_press)
+                        {
+                            return Some(binding);
                         }
                         text_editor_key_bindings(key_press)
                     })

--- a/src/app/app_menu.rs
+++ b/src/app/app_menu.rs
@@ -34,6 +34,8 @@ pub enum MenuAction {
     Search,
     /// Close the current open popup dialog
     CloseCurrentDialog,
+    /// Toggle Vim Mode
+    ToggleVimMode,
 }
 
 impl menu::action::MenuAction for MenuAction {
@@ -54,11 +56,15 @@ impl menu::action::MenuAction for MenuAction {
             MenuAction::PasteImage => Message::MenuAction(MenuAction::PasteImage),
             MenuAction::Search => Message::MenuAction(MenuAction::Search),
             MenuAction::CloseCurrentDialog => Message::MenuAction(MenuAction::CloseCurrentDialog),
+            MenuAction::ToggleVimMode => Message::MenuAction(MenuAction::ToggleVimMode),
         }
     }
 }
 
-pub fn menu_bar<'a>(key_binds: &HashMap<KeyBind, MenuAction>) -> Element<'a, Message> {
+pub fn menu_bar<'a>(
+    key_binds: &HashMap<KeyBind, MenuAction>,
+    vim_mode: bool,
+) -> Element<'a, Message> {
     menu::bar(vec![
         menu::Tree::with_children(
             menu::root(fl!("file")).apply(Element::from),
@@ -83,6 +89,13 @@ pub fn menu_bar<'a>(key_binds: &HashMap<KeyBind, MenuAction>) -> Element<'a, Mes
                     menu::Item::Button(fl!("redo"), None, MenuAction::Redo),
                     menu::Item::Button(fl!("paste-image"), None, MenuAction::PasteImage),
                     menu::Item::Button(fl!("search"), None, MenuAction::Search),
+                    menu::Item::Divider,
+                    menu::Item::CheckBox(
+                        fl!("vim-mode"),
+                        None,
+                        vim_mode,
+                        MenuAction::ToggleVimMode,
+                    ),
                 ],
             ),
         ),

--- a/src/app/core.rs
+++ b/src/app/core.rs
@@ -5,3 +5,4 @@ pub mod history;
 pub mod preview;
 pub mod project;
 pub mod utils;
+pub mod vim;

--- a/src/app/core/editor.rs
+++ b/src/app/core/editor.rs
@@ -5,6 +5,7 @@ use widgets::text_editor;
 
 use crate::app::core::{
     history::HistoryState, preview::MarkdownPreview, utils::search::SearchMatch,
+    vim::VimState,
 };
 
 pub struct EditorState {
@@ -20,6 +21,8 @@ pub struct EditorState {
     pub scroll: EditorScrollState,
     /// Holds the state of the search faetures of the editor
     pub search: EditorSearchState,
+    /// State of Vim mode for this editor
+    pub vim: VimState,
     /// Helper field to not open the external changes dialog when we save a file, move, delete...
     pub ignore_next_external_change: bool,
 }

--- a/src/app/core/vim.rs
+++ b/src/app/core/vim.rs
@@ -129,8 +129,10 @@ fn handle_normal_mode(
     // Ctrl shortcuts
     if modifiers.control() {
         match key.to_latin(physical_key) {
-            Some('u') | Some('b') => return repeat_motion(vim, Motion::PageUp),
-            Some('d') | Some('f') => return repeat_motion(vim, Motion::PageDown),
+            Some('u') => return repeat_motion_lines(vim, Motion::Up, 15),
+            Some('d') => return repeat_motion_lines(vim, Motion::Down, 15),
+            Some('b') => return repeat_motion_lines(vim, Motion::Up, 30),
+            Some('f') => return repeat_motion_lines(vim, Motion::Down, 30),
             Some('r') => return Some(Binding::Custom(Message::Redo)),
             _ => return None,
         }
@@ -163,8 +165,8 @@ fn handle_normal_mode(
         Key::Named(Named::ArrowDown) => repeat_motion(vim, Motion::Down),
         Key::Named(Named::Home) => repeat_motion(vim, Motion::Home),
         Key::Named(Named::End) => repeat_motion(vim, Motion::End),
-        Key::Named(Named::PageUp) => repeat_motion(vim, Motion::PageUp),
-        Key::Named(Named::PageDown) => repeat_motion(vim, Motion::PageDown),
+        Key::Named(Named::PageUp) => repeat_motion_lines(vim, Motion::Up, 30),
+        Key::Named(Named::PageDown) => repeat_motion_lines(vim, Motion::Down, 30),
         Key::Named(Named::Enter) => repeat_motion(vim, Motion::Down),
         Key::Named(Named::Backspace) => repeat_motion(vim, Motion::Left),
         Key::Named(Named::Tab) => Some(Binding::Sequence(vec![])),
@@ -339,8 +341,10 @@ fn handle_visual_mode(
     // Ctrl shortcuts
     if modifiers.control() {
         match key.to_latin(physical_key) {
-            Some('u') | Some('b') => return repeat_select(vim, Motion::PageUp),
-            Some('d') | Some('f') => return repeat_select(vim, Motion::PageDown),
+            Some('u') => return repeat_select_lines(vim, Motion::Up, 15),
+            Some('d') => return repeat_select_lines(vim, Motion::Down, 15),
+            Some('b') => return repeat_select_lines(vim, Motion::Up, 30),
+            Some('f') => return repeat_select_lines(vim, Motion::Down, 30),
             _ => return None,
         }
     }
@@ -371,8 +375,8 @@ fn handle_visual_mode(
         Key::Named(Named::ArrowDown) => repeat_select(vim, Motion::Down),
         Key::Named(Named::Home) => repeat_select(vim, Motion::Home),
         Key::Named(Named::End) => repeat_select(vim, Motion::End),
-        Key::Named(Named::PageUp) => repeat_select(vim, Motion::PageUp),
-        Key::Named(Named::PageDown) => repeat_select(vim, Motion::PageDown),
+        Key::Named(Named::PageUp) => repeat_select_lines(vim, Motion::Up, 30),
+        Key::Named(Named::PageDown) => repeat_select_lines(vim, Motion::Down, 30),
         Key::Named(Named::Enter) => repeat_select(vim, Motion::Down),
         Key::Named(Named::Backspace) => repeat_select(vim, Motion::Left),
         Key::Named(Named::Tab) => Some(Binding::Sequence(vec![])),
@@ -471,6 +475,16 @@ fn repeat_motion(vim: &mut VimState, motion: Motion) -> Option<Binding<Message>>
     }
 }
 
+fn repeat_motion_lines(
+    vim: &mut VimState,
+    motion: Motion,
+    default_lines: usize,
+) -> Option<Binding<Message>> {
+    let count = vim.count_prefix.take().unwrap_or(1);
+    let total = count * default_lines;
+    Some(Binding::Sequence(vec![Binding::Move(motion); total]))
+}
+
 fn repeat_select(vim: &mut VimState, motion: Motion) -> Option<Binding<Message>> {
     let count = vim.count_prefix.take().unwrap_or(1);
     if count <= 1 {
@@ -478,6 +492,16 @@ fn repeat_select(vim: &mut VimState, motion: Motion) -> Option<Binding<Message>>
     } else {
         Some(Binding::Sequence(vec![Binding::Select(motion); count]))
     }
+}
+
+fn repeat_select_lines(
+    vim: &mut VimState,
+    motion: Motion,
+    default_lines: usize,
+) -> Option<Binding<Message>> {
+    let count = vim.count_prefix.take().unwrap_or(1);
+    let total = count * default_lines;
+    Some(Binding::Sequence(vec![Binding::Select(motion); total]))
 }
 
 #[cfg(test)]
@@ -574,5 +598,27 @@ mod tests {
         let res = handle_vim_key_press(&mut vim, &kpd);
         assert_eq!(vim.mode, VimMode::Normal);
         assert!(matches!(res, Some(Binding::Sequence(_))));
+    }
+
+    #[test]
+    fn test_ctrl_u_ctrl_d_page_motions() {
+        let mut vim = VimState::default();
+        let kpd = make_key_press(Key::Character("d".into()), Modifiers::CTRL);
+        let res = handle_vim_key_press(&mut vim, &kpd);
+        if let Some(Binding::Sequence(seq)) = res {
+            assert_eq!(seq.len(), 15);
+            assert!(matches!(seq[0], Binding::Move(Motion::Down)));
+        } else {
+            panic!("Expected sequence of 15 moves down");
+        }
+
+        let kpu = make_key_press(Key::Character("u".into()), Modifiers::CTRL);
+        let res = handle_vim_key_press(&mut vim, &kpu);
+        if let Some(Binding::Sequence(seq)) = res {
+            assert_eq!(seq.len(), 15);
+            assert!(matches!(seq[0], Binding::Move(Motion::Up)));
+        } else {
+            panic!("Expected sequence of 15 moves up");
+        }
     }
 }

--- a/src/app/core/vim.rs
+++ b/src/app/core/vim.rs
@@ -1,0 +1,578 @@
+// SPDX-License-Identifier: GPL-3.0
+
+use cosmic::iced::keyboard::{self, key::Named, Key, Modifiers};
+use widgets::text_editor::{Binding, KeyPress, Motion, Status};
+
+use crate::app::{Message, VimAction};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum VimMode {
+    #[default]
+    Normal,
+    Insert,
+    Visual,
+    VisualLine,
+}
+
+impl VimMode {
+    pub fn label(&self) -> &'static str {
+        match self {
+            VimMode::Normal => "-- NORMAL --",
+            VimMode::Insert => "-- INSERT --",
+            VimMode::Visual => "-- VISUAL --",
+            VimMode::VisualLine => "-- VISUAL LINE --",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VimPendingOperator {
+    G, // 'g' pressed, waiting for 'g' (gg)
+    Y, // 'y' pressed in Normal mode, waiting for 'y' (yy)
+    D, // 'd' pressed in Normal mode, waiting for 'd' (dd)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct VimState {
+    pub mode: VimMode,
+    pub count_prefix: Option<usize>,
+    pub pending_operator: Option<VimPendingOperator>,
+    pub last_yank_is_line: bool,
+}
+
+impl VimState {
+    pub fn reset_operator_and_count(&mut self) {
+        self.pending_operator = None;
+        self.count_prefix = None;
+    }
+}
+
+/// Translates a key press event in Vim mode into a text editor [`Binding`].
+pub fn handle_vim_key_press(
+    vim: &mut VimState,
+    key_press: &KeyPress,
+) -> Option<Binding<Message>> {
+    let KeyPress {
+        key,
+        modified_key,
+        physical_key,
+        modifiers,
+        status,
+        ..
+    } = key_press;
+
+    if !matches!(status, Status::Focused { .. }) {
+        return None;
+    }
+
+    // Always intercept Escape in Vim mode so the editor remains focused and returns to Normal mode.
+    if matches!(modified_key, Key::Named(Named::Escape))
+        || (modifiers.control() && matches!(key.to_latin(*physical_key), Some('[')))
+    {
+        vim.reset_operator_and_count();
+        let was_insert = vim.mode == VimMode::Insert;
+        vim.mode = VimMode::Normal;
+
+        return if was_insert {
+            Some(Binding::Sequence(vec![
+                Binding::Move(Motion::Left),
+                Binding::Custom(Message::Vim(VimAction::Escape)),
+            ]))
+        } else {
+            Some(Binding::Custom(Message::Vim(VimAction::Escape)))
+        };
+    }
+
+    match vim.mode {
+        VimMode::Insert => {
+            // In Insert mode, pass through all keys to standard text editor bindings
+            None
+        }
+        VimMode::Normal => handle_normal_mode(vim, key, modified_key, *physical_key, *modifiers),
+        VimMode::Visual => handle_visual_mode(vim, key, modified_key, *physical_key, *modifiers, false),
+        VimMode::VisualLine => handle_visual_mode(vim, key, modified_key, *physical_key, *modifiers, true),
+    }
+}
+
+fn handle_normal_mode(
+    vim: &mut VimState,
+    key: &Key,
+    modified_key: &Key,
+    physical_key: keyboard::key::Physical,
+    modifiers: Modifiers,
+) -> Option<Binding<Message>> {
+    // Check pending operators first
+    if let Some(pending) = vim.pending_operator {
+        vim.pending_operator = None;
+        match pending {
+            VimPendingOperator::G => {
+                if matches!(key.to_latin(physical_key), Some('g')) {
+                    vim.count_prefix = None;
+                    return Some(Binding::Custom(Message::Vim(VimAction::GoToTop)));
+                }
+            }
+            VimPendingOperator::Y => {
+                if matches!(key.to_latin(physical_key), Some('y')) {
+                    vim.count_prefix = None;
+                    return Some(Binding::Custom(Message::Vim(VimAction::YankLine)));
+                }
+            }
+            VimPendingOperator::D => {
+                if matches!(key.to_latin(physical_key), Some('d')) {
+                    vim.count_prefix = None;
+                    return Some(Binding::Custom(Message::Vim(VimAction::DeleteLine)));
+                }
+            }
+        }
+    }
+
+    // Ctrl shortcuts
+    if modifiers.control() {
+        match key.to_latin(physical_key) {
+            Some('u') | Some('b') => return repeat_motion(vim, Motion::PageUp),
+            Some('d') | Some('f') => return repeat_motion(vim, Motion::PageDown),
+            Some('r') => return Some(Binding::Custom(Message::Redo)),
+            _ => return None,
+        }
+    }
+
+    // Pass through system Command/Ctrl shortcuts (e.g. Save, Copy, Paste, etc.)
+    if modifiers.command() {
+        return None;
+    }
+
+    // Digits for count prefix (e.g. 5j, 10w)
+    if !modifiers.control() && !modifiers.alt() && !modifiers.command() {
+        if let Key::Character(s) = key {
+            if let Some(c) = s.chars().next() {
+                if ('1'..='9').contains(&c) || (c == '0' && vim.count_prefix.is_some()) {
+                    let digit = c.to_digit(10).unwrap() as usize;
+                    let new_count = vim.count_prefix.unwrap_or(0) * 10 + digit;
+                    vim.count_prefix = Some(new_count);
+                    return Some(Binding::Sequence(vec![])); // Consume digit keypress
+                }
+            }
+        }
+    }
+
+    // Single-key commands and motions
+    match modified_key {
+        Key::Named(Named::ArrowLeft) => repeat_motion(vim, Motion::Left),
+        Key::Named(Named::ArrowRight) => repeat_motion(vim, Motion::Right),
+        Key::Named(Named::ArrowUp) => repeat_motion(vim, Motion::Up),
+        Key::Named(Named::ArrowDown) => repeat_motion(vim, Motion::Down),
+        Key::Named(Named::Home) => repeat_motion(vim, Motion::Home),
+        Key::Named(Named::End) => repeat_motion(vim, Motion::End),
+        Key::Named(Named::PageUp) => repeat_motion(vim, Motion::PageUp),
+        Key::Named(Named::PageDown) => repeat_motion(vim, Motion::PageDown),
+        Key::Named(Named::Enter) => repeat_motion(vim, Motion::Down),
+        Key::Named(Named::Backspace) => repeat_motion(vim, Motion::Left),
+        Key::Named(Named::Tab) => Some(Binding::Sequence(vec![])),
+        _ => {
+            if modifiers.control() || modifiers.alt() || modifiers.command() {
+                return None;
+            }
+
+            match key.to_latin(physical_key) {
+                // Movement: Directional
+                Some(' ') => repeat_motion(vim, Motion::Right),
+                Some('h') => repeat_motion(vim, Motion::Left),
+                Some('j') => repeat_motion(vim, Motion::Down),
+                Some('k') => repeat_motion(vim, Motion::Up),
+                Some('l') => repeat_motion(vim, Motion::Right),
+
+                // Movement: Words
+                Some('w') => repeat_motion(vim, Motion::Right.widen()),
+                Some('b') => repeat_motion(vim, Motion::Left.widen()),
+                Some('e') => repeat_motion(vim, Motion::Right.widen()),
+
+                // Movement: Line boundaries
+                Some('0') | Some('^') => {
+                    vim.count_prefix = None;
+                    Some(Binding::Move(Motion::Home))
+                }
+                Some('$') => {
+                    vim.count_prefix = None;
+                    Some(Binding::Move(Motion::End))
+                }
+
+                // Movement: Buffer boundaries
+                Some('g') => {
+                    vim.pending_operator = Some(VimPendingOperator::G);
+                    Some(Binding::Sequence(vec![])) // Wait for second 'g'
+                }
+                Some('G') if modifiers.shift() => {
+                    vim.count_prefix = None;
+                    Some(Binding::Custom(Message::Vim(VimAction::GoToBottom)))
+                }
+
+                // Mode Switching: Insert
+                Some('i') => {
+                    vim.reset_operator_and_count();
+                    vim.mode = VimMode::Insert;
+                    Some(Binding::Custom(Message::Vim(VimAction::SetMode(VimMode::Insert))))
+                }
+                Some('I') if modifiers.shift() => {
+                    vim.reset_operator_and_count();
+                    vim.mode = VimMode::Insert;
+                    Some(Binding::Sequence(vec![
+                        Binding::Move(Motion::Home),
+                        Binding::Custom(Message::Vim(VimAction::SetMode(VimMode::Insert))),
+                    ]))
+                }
+                Some('a') => {
+                    vim.reset_operator_and_count();
+                    vim.mode = VimMode::Insert;
+                    Some(Binding::Sequence(vec![
+                        Binding::Move(Motion::Right),
+                        Binding::Custom(Message::Vim(VimAction::SetMode(VimMode::Insert))),
+                    ]))
+                }
+                Some('A') if modifiers.shift() => {
+                    vim.reset_operator_and_count();
+                    vim.mode = VimMode::Insert;
+                    Some(Binding::Sequence(vec![
+                        Binding::Move(Motion::End),
+                        Binding::Custom(Message::Vim(VimAction::SetMode(VimMode::Insert))),
+                    ]))
+                }
+                Some('o') => {
+                    vim.reset_operator_and_count();
+                    vim.mode = VimMode::Insert;
+                    Some(Binding::Sequence(vec![
+                        Binding::Move(Motion::End),
+                        Binding::Enter,
+                        Binding::Custom(Message::Vim(VimAction::SetMode(VimMode::Insert))),
+                    ]))
+                }
+                Some('O') if modifiers.shift() => {
+                    vim.reset_operator_and_count();
+                    vim.mode = VimMode::Insert;
+                    Some(Binding::Sequence(vec![
+                        Binding::Move(Motion::Home),
+                        Binding::Enter,
+                        Binding::Move(Motion::Up),
+                        Binding::Custom(Message::Vim(VimAction::SetMode(VimMode::Insert))),
+                    ]))
+                }
+
+                // Mode Switching: Visual
+                Some('v') => {
+                    vim.reset_operator_and_count();
+                    vim.mode = VimMode::Visual;
+                    Some(Binding::Custom(Message::Vim(VimAction::SetMode(VimMode::Visual))))
+                }
+                Some('V') if modifiers.shift() => {
+                    vim.reset_operator_and_count();
+                    vim.mode = VimMode::VisualLine;
+                    Some(Binding::Sequence(vec![
+                        Binding::SelectLine,
+                        Binding::Custom(Message::Vim(VimAction::SetMode(VimMode::VisualLine))),
+                    ]))
+                }
+
+                // Copy (Yank)
+                Some('y') => {
+                    vim.pending_operator = Some(VimPendingOperator::Y);
+                    Some(Binding::Sequence(vec![])) // Wait for second 'y'
+                }
+                Some('Y') if modifiers.shift() => {
+                    vim.reset_operator_and_count();
+                    Some(Binding::Custom(Message::Vim(VimAction::YankLine)))
+                }
+
+                // Delete (dd or D)
+                Some('d') => {
+                    vim.pending_operator = Some(VimPendingOperator::D);
+                    Some(Binding::Sequence(vec![])) // Wait for second 'd'
+                }
+                Some('D') if modifiers.shift() => {
+                    vim.reset_operator_and_count();
+                    Some(Binding::Sequence(vec![
+                        Binding::Select(Motion::End),
+                        Binding::Delete,
+                    ]))
+                }
+
+                // Paste (Put)
+                Some('p') => {
+                    vim.reset_operator_and_count();
+                    Some(Binding::Custom(Message::Vim(VimAction::Paste { before: false })))
+                }
+                Some('P') if modifiers.shift() => {
+                    vim.reset_operator_and_count();
+                    Some(Binding::Custom(Message::Vim(VimAction::Paste { before: true })))
+                }
+
+                // Single character delete / Undo
+                Some('x') => {
+                    vim.reset_operator_and_count();
+                    Some(Binding::Delete)
+                }
+                Some('X') if modifiers.shift() => {
+                    vim.reset_operator_and_count();
+                    Some(Binding::Backspace)
+                }
+                Some('u') => {
+                    vim.reset_operator_and_count();
+                    Some(Binding::Custom(Message::Undo))
+                }
+
+                // Consume any other character key so NO letters are inserted in Normal mode
+                _ => {
+                    vim.reset_operator_and_count();
+                    Some(Binding::Sequence(vec![]))
+                }
+            }
+        }
+    }
+}
+
+fn handle_visual_mode(
+    vim: &mut VimState,
+    key: &Key,
+    modified_key: &Key,
+    physical_key: keyboard::key::Physical,
+    modifiers: Modifiers,
+    is_line: bool,
+) -> Option<Binding<Message>> {
+    // Ctrl shortcuts
+    if modifiers.control() {
+        match key.to_latin(physical_key) {
+            Some('u') | Some('b') => return repeat_select(vim, Motion::PageUp),
+            Some('d') | Some('f') => return repeat_select(vim, Motion::PageDown),
+            _ => return None,
+        }
+    }
+
+    if modifiers.command() {
+        return None;
+    }
+
+    // Digits for count prefix
+    if !modifiers.control() && !modifiers.alt() && !modifiers.command() {
+        if let Key::Character(s) = key {
+            if let Some(c) = s.chars().next() {
+                if ('1'..='9').contains(&c) || (c == '0' && vim.count_prefix.is_some()) {
+                    let digit = c.to_digit(10).unwrap() as usize;
+                    let new_count = vim.count_prefix.unwrap_or(0) * 10 + digit;
+                    vim.count_prefix = Some(new_count);
+                    return Some(Binding::Sequence(vec![]));
+                }
+            }
+        }
+    }
+
+    // Single key motions / selections
+    match modified_key {
+        Key::Named(Named::ArrowLeft) => repeat_select(vim, Motion::Left),
+        Key::Named(Named::ArrowRight) => repeat_select(vim, Motion::Right),
+        Key::Named(Named::ArrowUp) => repeat_select(vim, Motion::Up),
+        Key::Named(Named::ArrowDown) => repeat_select(vim, Motion::Down),
+        Key::Named(Named::Home) => repeat_select(vim, Motion::Home),
+        Key::Named(Named::End) => repeat_select(vim, Motion::End),
+        Key::Named(Named::PageUp) => repeat_select(vim, Motion::PageUp),
+        Key::Named(Named::PageDown) => repeat_select(vim, Motion::PageDown),
+        Key::Named(Named::Enter) => repeat_select(vim, Motion::Down),
+        Key::Named(Named::Backspace) => repeat_select(vim, Motion::Left),
+        Key::Named(Named::Tab) => Some(Binding::Sequence(vec![])),
+        _ => {
+            if modifiers.control() || modifiers.alt() || modifiers.command() {
+                return None;
+            }
+
+            match key.to_latin(physical_key) {
+                // Movement: Directional
+                Some(' ') => repeat_select(vim, Motion::Right),
+                Some('h') => repeat_select(vim, Motion::Left),
+                Some('j') => repeat_select(vim, Motion::Down),
+                Some('k') => repeat_select(vim, Motion::Up),
+                Some('l') => repeat_select(vim, Motion::Right),
+
+                // Movement: Words
+                Some('w') => repeat_select(vim, Motion::Right.widen()),
+                Some('b') => repeat_select(vim, Motion::Left.widen()),
+                Some('e') => repeat_select(vim, Motion::Right.widen()),
+
+                // Movement: Line boundaries
+                Some('0') | Some('^') => {
+                    vim.count_prefix = None;
+                    Some(Binding::Select(Motion::Home))
+                }
+                Some('$') => {
+                    vim.count_prefix = None;
+                    Some(Binding::Select(Motion::End))
+                }
+
+                // Movement: Buffer boundaries
+                Some('g') => {
+                    vim.count_prefix = None;
+                    Some(Binding::Custom(Message::Vim(VimAction::VisualGoToTop)))
+                }
+                Some('G') if modifiers.shift() => {
+                    vim.count_prefix = None;
+                    Some(Binding::Custom(Message::Vim(VimAction::VisualGoToBottom)))
+                }
+
+                // Copy (Yank) selected text
+                Some('y') | Some('Y') => {
+                    vim.reset_operator_and_count();
+                    vim.mode = VimMode::Normal;
+                    vim.last_yank_is_line = is_line;
+                    Some(Binding::Sequence(vec![
+                        Binding::Copy,
+                        Binding::Custom(Message::Vim(VimAction::SetMode(VimMode::Normal))),
+                    ]))
+                }
+
+                // Delete selected text
+                Some('d') | Some('D') | Some('x') | Some('X') => {
+                    vim.reset_operator_and_count();
+                    vim.mode = VimMode::Normal;
+                    Some(Binding::Sequence(vec![
+                        Binding::Delete,
+                        Binding::Custom(Message::Vim(VimAction::SetMode(VimMode::Normal))),
+                    ]))
+                }
+
+                // Paste (Replace selection with clipboard text)
+                Some('p') | Some('P') => {
+                    vim.reset_operator_and_count();
+                    vim.mode = VimMode::Normal;
+                    Some(Binding::Sequence(vec![
+                        Binding::Paste,
+                        Binding::Custom(Message::Vim(VimAction::SetMode(VimMode::Normal))),
+                    ]))
+                }
+
+                // Toggle back to Normal mode on 'v' or 'V'
+                Some('v') | Some('V') => {
+                    vim.reset_operator_and_count();
+                    vim.mode = VimMode::Normal;
+                    Some(Binding::Custom(Message::Vim(VimAction::Escape)))
+                }
+
+                // Consume any other character key so NO letters are inserted in Visual mode
+                _ => {
+                    vim.reset_operator_and_count();
+                    Some(Binding::Sequence(vec![]))
+                }
+            }
+        }
+    }
+}
+
+fn repeat_motion(vim: &mut VimState, motion: Motion) -> Option<Binding<Message>> {
+    let count = vim.count_prefix.take().unwrap_or(1);
+    if count <= 1 {
+        Some(Binding::Move(motion))
+    } else {
+        Some(Binding::Sequence(vec![Binding::Move(motion); count]))
+    }
+}
+
+fn repeat_select(vim: &mut VimState, motion: Motion) -> Option<Binding<Message>> {
+    let count = vim.count_prefix.take().unwrap_or(1);
+    if count <= 1 {
+        Some(Binding::Select(motion))
+    } else {
+        Some(Binding::Sequence(vec![Binding::Select(motion); count]))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cosmic::iced::keyboard::key::Named;
+
+    fn make_key_press(key: Key, modifiers: Modifiers) -> KeyPress {
+        KeyPress {
+            key: key.clone(),
+            modified_key: key,
+            physical_key: keyboard::key::Physical::Unidentified(keyboard::key::NativeCode::Unidentified),
+            modifiers,
+            text: None,
+            status: Status::Focused { is_hovered: true },
+        }
+    }
+
+    #[test]
+    fn test_normal_mode_motions() {
+        let mut vim = VimState::default();
+        let kp = make_key_press(Key::Character("j".into()), Modifiers::default());
+        let res = handle_vim_key_press(&mut vim, &kp);
+        assert!(matches!(res, Some(Binding::Move(Motion::Down))));
+    }
+
+    #[test]
+    fn test_count_prefix_motion() {
+        let mut vim = VimState::default();
+        let kp5 = make_key_press(Key::Character("5".into()), Modifiers::default());
+        let _ = handle_vim_key_press(&mut vim, &kp5);
+        assert_eq!(vim.count_prefix, Some(5));
+
+        let kpj = make_key_press(Key::Character("j".into()), Modifiers::default());
+        let res = handle_vim_key_press(&mut vim, &kpj);
+        if let Some(Binding::Sequence(seq)) = res {
+            assert_eq!(seq.len(), 5);
+            assert!(matches!(seq[0], Binding::Move(Motion::Down)));
+        } else {
+            panic!("Expected sequence of 5 moves");
+        }
+        assert_eq!(vim.count_prefix, None);
+    }
+
+    #[test]
+    fn test_mode_transitions() {
+        let mut vim = VimState::default();
+        let kpi = make_key_press(Key::Character("i".into()), Modifiers::default());
+        let _ = handle_vim_key_press(&mut vim, &kpi);
+        assert_eq!(vim.mode, VimMode::Insert);
+
+        let kpesc = make_key_press(Key::Named(Named::Escape), Modifiers::default());
+        let _ = handle_vim_key_press(&mut vim, &kpesc);
+        assert_eq!(vim.mode, VimMode::Normal);
+    }
+
+    #[test]
+    fn test_visual_mode_yank() {
+        let mut vim = VimState::default();
+        vim.mode = VimMode::Visual;
+        let kpy = make_key_press(Key::Character("y".into()), Modifiers::default());
+        let res = handle_vim_key_press(&mut vim, &kpy);
+        assert_eq!(vim.mode, VimMode::Normal);
+        assert!(matches!(res, Some(Binding::Sequence(_))));
+    }
+
+    #[test]
+    fn test_normal_mode_dd_deletes_line() {
+        let mut vim = VimState::default();
+        let kpd = make_key_press(Key::Character("d".into()), Modifiers::default());
+        let res1 = handle_vim_key_press(&mut vim, &kpd);
+        assert!(matches!(res1, Some(Binding::Sequence(seq)) if seq.is_empty()));
+        assert_eq!(vim.pending_operator, Some(VimPendingOperator::D));
+
+        let res2 = handle_vim_key_press(&mut vim, &kpd);
+        assert!(matches!(res2, Some(Binding::Custom(Message::Vim(VimAction::DeleteLine)))));
+        assert_eq!(vim.pending_operator, None);
+    }
+
+    #[test]
+    fn test_normal_mode_unhandled_letters_consumed() {
+        let mut vim = VimState::default();
+        let kpz = make_key_press(Key::Character("z".into()), Modifiers::default());
+        let res = handle_vim_key_press(&mut vim, &kpz);
+        // Unhandled letters must return an empty sequence to consume the key without inserting text
+        assert!(matches!(res, Some(Binding::Sequence(seq)) if seq.is_empty()));
+    }
+
+    #[test]
+    fn test_visual_mode_delete() {
+        let mut vim = VimState::default();
+        vim.mode = VimMode::Visual;
+        let kpd = make_key_press(Key::Character("d".into()), Modifiers::default());
+        let res = handle_vim_key_press(&mut vim, &kpd);
+        assert_eq!(vim.mode, VimMode::Normal);
+        assert!(matches!(res, Some(Binding::Sequence(_))));
+    }
+}

--- a/src/app/core/vim.rs
+++ b/src/app/core/vim.rs
@@ -48,8 +48,11 @@ impl VimState {
 }
 
 /// Translates a key press event in Vim mode into a text editor [`Binding`].
+///
+/// This is a pure function that does not mutate state. Any required state transitions
+/// are returned as messages (`Message::Vim(VimAction::...)`) to be processed by the update function.
 pub fn handle_vim_key_press(
-    vim: &mut VimState,
+    vim: &VimState,
     key_press: &KeyPress,
 ) -> Option<Binding<Message>> {
     let KeyPress {
@@ -69,9 +72,7 @@ pub fn handle_vim_key_press(
     if matches!(modified_key, Key::Named(Named::Escape))
         || (modifiers.control() && matches!(key.to_latin(*physical_key), Some('[')))
     {
-        vim.reset_operator_and_count();
         let was_insert = vim.mode == VimMode::Insert;
-        vim.mode = VimMode::Normal;
 
         return if was_insert {
             Some(Binding::Sequence(vec![
@@ -95,7 +96,7 @@ pub fn handle_vim_key_press(
 }
 
 fn handle_normal_mode(
-    vim: &mut VimState,
+    vim: &VimState,
     key: &Key,
     modified_key: &Key,
     physical_key: keyboard::key::Physical,
@@ -103,23 +104,19 @@ fn handle_normal_mode(
 ) -> Option<Binding<Message>> {
     // Check pending operators first
     if let Some(pending) = vim.pending_operator {
-        vim.pending_operator = None;
         match pending {
             VimPendingOperator::G => {
                 if matches!(key.to_latin(physical_key), Some('g')) {
-                    vim.count_prefix = None;
                     return Some(Binding::Custom(Message::Vim(VimAction::GoToTop)));
                 }
             }
             VimPendingOperator::Y => {
                 if matches!(key.to_latin(physical_key), Some('y')) {
-                    vim.count_prefix = None;
                     return Some(Binding::Custom(Message::Vim(VimAction::YankLine)));
                 }
             }
             VimPendingOperator::D => {
                 if matches!(key.to_latin(physical_key), Some('d')) {
-                    vim.count_prefix = None;
                     return Some(Binding::Custom(Message::Vim(VimAction::DeleteLine)));
                 }
             }
@@ -133,7 +130,16 @@ fn handle_normal_mode(
             Some('d') => return repeat_motion_lines(vim, Motion::Down, 15),
             Some('b') => return repeat_motion_lines(vim, Motion::Up, 30),
             Some('f') => return repeat_motion_lines(vim, Motion::Down, 30),
-            Some('r') => return Some(Binding::Custom(Message::Redo)),
+            Some('r') => {
+                if vim.pending_operator.is_some() || vim.count_prefix.is_some() {
+                    return Some(Binding::Sequence(vec![
+                        Binding::Custom(Message::Redo),
+                        Binding::Custom(Message::Vim(VimAction::ResetOperatorAndCount)),
+                    ]));
+                } else {
+                    return Some(Binding::Custom(Message::Redo));
+                }
+            }
             _ => return None,
         }
     }
@@ -144,17 +150,18 @@ fn handle_normal_mode(
     }
 
     // Digits for count prefix (e.g. 5j, 10w)
-    if !modifiers.control() && !modifiers.alt() && !modifiers.command() {
-        if let Key::Character(s) = key {
-            if let Some(c) = s.chars().next() {
-                if ('1'..='9').contains(&c) || (c == '0' && vim.count_prefix.is_some()) {
-                    let digit = c.to_digit(10).unwrap() as usize;
-                    let new_count = vim.count_prefix.unwrap_or(0) * 10 + digit;
-                    vim.count_prefix = Some(new_count);
-                    return Some(Binding::Sequence(vec![])); // Consume digit keypress
-                }
-            }
-        }
+    if !modifiers.control()
+        && !modifiers.alt()
+        && !modifiers.command()
+        && let Key::Character(s) = key
+        && let Some(c) = s.chars().next()
+        && (('1'..='9').contains(&c) || (c == '0' && vim.count_prefix.is_some()))
+    {
+        let digit = c.to_digit(10).unwrap() as usize;
+        let new_count = vim.count_prefix.unwrap_or(0) * 10 + digit;
+        return Some(Binding::Custom(Message::Vim(VimAction::SetCountPrefix(
+            Some(new_count),
+        ))));
     }
 
     // Single-key commands and motions
@@ -169,7 +176,15 @@ fn handle_normal_mode(
         Key::Named(Named::PageDown) => repeat_motion_lines(vim, Motion::Down, 30),
         Key::Named(Named::Enter) => repeat_motion(vim, Motion::Down),
         Key::Named(Named::Backspace) => repeat_motion(vim, Motion::Left),
-        Key::Named(Named::Tab) => Some(Binding::Sequence(vec![])),
+        Key::Named(Named::Tab) => {
+            if vim.count_prefix.is_some() || vim.pending_operator.is_some() {
+                Some(Binding::Custom(Message::Vim(
+                    VimAction::ResetOperatorAndCount,
+                )))
+            } else {
+                Some(Binding::Sequence(vec![]))
+            }
+        }
         _ => {
             if modifiers.control() || modifiers.alt() || modifiers.command() {
                 return None;
@@ -190,140 +205,142 @@ fn handle_normal_mode(
 
                 // Movement: Line boundaries
                 Some('0') | Some('^') => {
-                    vim.count_prefix = None;
-                    Some(Binding::Move(Motion::Home))
+                    if vim.count_prefix.is_some() || vim.pending_operator.is_some() {
+                        Some(Binding::Sequence(vec![
+                            Binding::Move(Motion::Home),
+                            Binding::Custom(Message::Vim(VimAction::ResetOperatorAndCount)),
+                        ]))
+                    } else {
+                        Some(Binding::Move(Motion::Home))
+                    }
                 }
                 Some('$') => {
-                    vim.count_prefix = None;
-                    Some(Binding::Move(Motion::End))
+                    if vim.count_prefix.is_some() || vim.pending_operator.is_some() {
+                        Some(Binding::Sequence(vec![
+                            Binding::Move(Motion::End),
+                            Binding::Custom(Message::Vim(VimAction::ResetOperatorAndCount)),
+                        ]))
+                    } else {
+                        Some(Binding::Move(Motion::End))
+                    }
                 }
 
                 // Movement: Buffer boundaries
-                Some('g') => {
-                    vim.pending_operator = Some(VimPendingOperator::G);
-                    Some(Binding::Sequence(vec![])) // Wait for second 'g'
-                }
+                Some('g') => Some(Binding::Custom(Message::Vim(
+                    VimAction::SetPendingOperator(Some(VimPendingOperator::G)),
+                ))),
                 Some('G') if modifiers.shift() => {
-                    vim.count_prefix = None;
                     Some(Binding::Custom(Message::Vim(VimAction::GoToBottom)))
                 }
 
                 // Mode Switching: Insert
                 Some('i') => {
-                    vim.reset_operator_and_count();
-                    vim.mode = VimMode::Insert;
-                    Some(Binding::Custom(Message::Vim(VimAction::SetMode(VimMode::Insert))))
+                    Some(Binding::Custom(Message::Vim(VimAction::SetMode(
+                        VimMode::Insert,
+                    ))))
                 }
-                Some('I') if modifiers.shift() => {
-                    vim.reset_operator_and_count();
-                    vim.mode = VimMode::Insert;
-                    Some(Binding::Sequence(vec![
-                        Binding::Move(Motion::Home),
-                        Binding::Custom(Message::Vim(VimAction::SetMode(VimMode::Insert))),
-                    ]))
-                }
-                Some('a') => {
-                    vim.reset_operator_and_count();
-                    vim.mode = VimMode::Insert;
-                    Some(Binding::Sequence(vec![
-                        Binding::Move(Motion::Right),
-                        Binding::Custom(Message::Vim(VimAction::SetMode(VimMode::Insert))),
-                    ]))
-                }
-                Some('A') if modifiers.shift() => {
-                    vim.reset_operator_and_count();
-                    vim.mode = VimMode::Insert;
-                    Some(Binding::Sequence(vec![
-                        Binding::Move(Motion::End),
-                        Binding::Custom(Message::Vim(VimAction::SetMode(VimMode::Insert))),
-                    ]))
-                }
-                Some('o') => {
-                    vim.reset_operator_and_count();
-                    vim.mode = VimMode::Insert;
-                    Some(Binding::Sequence(vec![
-                        Binding::Move(Motion::End),
-                        Binding::Enter,
-                        Binding::Custom(Message::Vim(VimAction::SetMode(VimMode::Insert))),
-                    ]))
-                }
-                Some('O') if modifiers.shift() => {
-                    vim.reset_operator_and_count();
-                    vim.mode = VimMode::Insert;
-                    Some(Binding::Sequence(vec![
-                        Binding::Move(Motion::Home),
-                        Binding::Enter,
-                        Binding::Move(Motion::Up),
-                        Binding::Custom(Message::Vim(VimAction::SetMode(VimMode::Insert))),
-                    ]))
-                }
+                Some('I') if modifiers.shift() => Some(Binding::Sequence(vec![
+                    Binding::Move(Motion::Home),
+                    Binding::Custom(Message::Vim(VimAction::SetMode(VimMode::Insert))),
+                ])),
+                Some('a') => Some(Binding::Sequence(vec![
+                    Binding::Move(Motion::Right),
+                    Binding::Custom(Message::Vim(VimAction::SetMode(VimMode::Insert))),
+                ])),
+                Some('A') if modifiers.shift() => Some(Binding::Sequence(vec![
+                    Binding::Move(Motion::End),
+                    Binding::Custom(Message::Vim(VimAction::SetMode(VimMode::Insert))),
+                ])),
+                Some('o') => Some(Binding::Sequence(vec![
+                    Binding::Move(Motion::End),
+                    Binding::Enter,
+                    Binding::Custom(Message::Vim(VimAction::SetMode(VimMode::Insert))),
+                ])),
+                Some('O') if modifiers.shift() => Some(Binding::Sequence(vec![
+                    Binding::Move(Motion::Home),
+                    Binding::Enter,
+                    Binding::Move(Motion::Up),
+                    Binding::Custom(Message::Vim(VimAction::SetMode(VimMode::Insert))),
+                ])),
 
                 // Mode Switching: Visual
                 Some('v') => {
-                    vim.reset_operator_and_count();
-                    vim.mode = VimMode::Visual;
-                    Some(Binding::Custom(Message::Vim(VimAction::SetMode(VimMode::Visual))))
+                    Some(Binding::Custom(Message::Vim(VimAction::SetMode(
+                        VimMode::Visual,
+                    ))))
                 }
-                Some('V') if modifiers.shift() => {
-                    vim.reset_operator_and_count();
-                    vim.mode = VimMode::VisualLine;
-                    Some(Binding::Sequence(vec![
-                        Binding::SelectLine,
-                        Binding::Custom(Message::Vim(VimAction::SetMode(VimMode::VisualLine))),
-                    ]))
-                }
+                Some('V') if modifiers.shift() => Some(Binding::Sequence(vec![
+                    Binding::SelectLine,
+                    Binding::Custom(Message::Vim(VimAction::SetMode(VimMode::VisualLine))),
+                ])),
 
                 // Copy (Yank)
-                Some('y') => {
-                    vim.pending_operator = Some(VimPendingOperator::Y);
-                    Some(Binding::Sequence(vec![])) // Wait for second 'y'
-                }
+                Some('y') => Some(Binding::Custom(Message::Vim(
+                    VimAction::SetPendingOperator(Some(VimPendingOperator::Y)),
+                ))),
                 Some('Y') if modifiers.shift() => {
-                    vim.reset_operator_and_count();
                     Some(Binding::Custom(Message::Vim(VimAction::YankLine)))
                 }
 
                 // Delete (dd or D)
-                Some('d') => {
-                    vim.pending_operator = Some(VimPendingOperator::D);
-                    Some(Binding::Sequence(vec![])) // Wait for second 'd'
-                }
-                Some('D') if modifiers.shift() => {
-                    vim.reset_operator_and_count();
-                    Some(Binding::Sequence(vec![
-                        Binding::Select(Motion::End),
-                        Binding::Delete,
-                    ]))
-                }
+                Some('d') => Some(Binding::Custom(Message::Vim(
+                    VimAction::SetPendingOperator(Some(VimPendingOperator::D)),
+                ))),
+                Some('D') if modifiers.shift() => Some(Binding::Sequence(vec![
+                    Binding::Select(Motion::End),
+                    Binding::Delete,
+                    Binding::Custom(Message::Vim(VimAction::ResetOperatorAndCount)),
+                ])),
 
                 // Paste (Put)
                 Some('p') => {
-                    vim.reset_operator_and_count();
                     Some(Binding::Custom(Message::Vim(VimAction::Paste { before: false })))
                 }
                 Some('P') if modifiers.shift() => {
-                    vim.reset_operator_and_count();
                     Some(Binding::Custom(Message::Vim(VimAction::Paste { before: true })))
                 }
 
                 // Single character delete / Undo
                 Some('x') => {
-                    vim.reset_operator_and_count();
-                    Some(Binding::Delete)
+                    if vim.count_prefix.is_some() || vim.pending_operator.is_some() {
+                        Some(Binding::Sequence(vec![
+                            Binding::Delete,
+                            Binding::Custom(Message::Vim(VimAction::ResetOperatorAndCount)),
+                        ]))
+                    } else {
+                        Some(Binding::Delete)
+                    }
                 }
                 Some('X') if modifiers.shift() => {
-                    vim.reset_operator_and_count();
-                    Some(Binding::Backspace)
+                    if vim.count_prefix.is_some() || vim.pending_operator.is_some() {
+                        Some(Binding::Sequence(vec![
+                            Binding::Backspace,
+                            Binding::Custom(Message::Vim(VimAction::ResetOperatorAndCount)),
+                        ]))
+                    } else {
+                        Some(Binding::Backspace)
+                    }
                 }
                 Some('u') => {
-                    vim.reset_operator_and_count();
-                    Some(Binding::Custom(Message::Undo))
+                    if vim.count_prefix.is_some() || vim.pending_operator.is_some() {
+                        Some(Binding::Sequence(vec![
+                            Binding::Custom(Message::Undo),
+                            Binding::Custom(Message::Vim(VimAction::ResetOperatorAndCount)),
+                        ]))
+                    } else {
+                        Some(Binding::Custom(Message::Undo))
+                    }
                 }
 
                 // Consume any other character key so NO letters are inserted in Normal mode
                 _ => {
-                    vim.reset_operator_and_count();
-                    Some(Binding::Sequence(vec![]))
+                    if vim.count_prefix.is_some() || vim.pending_operator.is_some() {
+                        Some(Binding::Custom(Message::Vim(
+                            VimAction::ResetOperatorAndCount,
+                        )))
+                    } else {
+                        Some(Binding::Sequence(vec![]))
+                    }
                 }
             }
         }
@@ -331,7 +348,7 @@ fn handle_normal_mode(
 }
 
 fn handle_visual_mode(
-    vim: &mut VimState,
+    vim: &VimState,
     key: &Key,
     modified_key: &Key,
     physical_key: keyboard::key::Physical,
@@ -354,17 +371,18 @@ fn handle_visual_mode(
     }
 
     // Digits for count prefix
-    if !modifiers.control() && !modifiers.alt() && !modifiers.command() {
-        if let Key::Character(s) = key {
-            if let Some(c) = s.chars().next() {
-                if ('1'..='9').contains(&c) || (c == '0' && vim.count_prefix.is_some()) {
-                    let digit = c.to_digit(10).unwrap() as usize;
-                    let new_count = vim.count_prefix.unwrap_or(0) * 10 + digit;
-                    vim.count_prefix = Some(new_count);
-                    return Some(Binding::Sequence(vec![]));
-                }
-            }
-        }
+    if !modifiers.control()
+        && !modifiers.alt()
+        && !modifiers.command()
+        && let Key::Character(s) = key
+        && let Some(c) = s.chars().next()
+        && (('1'..='9').contains(&c) || (c == '0' && vim.count_prefix.is_some()))
+    {
+        let digit = c.to_digit(10).unwrap() as usize;
+        let new_count = vim.count_prefix.unwrap_or(0) * 10 + digit;
+        return Some(Binding::Custom(Message::Vim(VimAction::SetCountPrefix(
+            Some(new_count),
+        ))));
     }
 
     // Single key motions / selections
@@ -379,7 +397,15 @@ fn handle_visual_mode(
         Key::Named(Named::PageDown) => repeat_select_lines(vim, Motion::Down, 30),
         Key::Named(Named::Enter) => repeat_select(vim, Motion::Down),
         Key::Named(Named::Backspace) => repeat_select(vim, Motion::Left),
-        Key::Named(Named::Tab) => Some(Binding::Sequence(vec![])),
+        Key::Named(Named::Tab) => {
+            if vim.count_prefix.is_some() {
+                Some(Binding::Custom(Message::Vim(
+                    VimAction::ResetOperatorAndCount,
+                )))
+            } else {
+                Some(Binding::Sequence(vec![]))
+            }
+        }
         _ => {
             if modifiers.control() || modifiers.alt() || modifiers.command() {
                 return None;
@@ -400,108 +426,144 @@ fn handle_visual_mode(
 
                 // Movement: Line boundaries
                 Some('0') | Some('^') => {
-                    vim.count_prefix = None;
-                    Some(Binding::Select(Motion::Home))
+                    if vim.count_prefix.is_some() {
+                        Some(Binding::Sequence(vec![
+                            Binding::Select(Motion::Home),
+                            Binding::Custom(Message::Vim(VimAction::ResetOperatorAndCount)),
+                        ]))
+                    } else {
+                        Some(Binding::Select(Motion::Home))
+                    }
                 }
                 Some('$') => {
-                    vim.count_prefix = None;
-                    Some(Binding::Select(Motion::End))
+                    if vim.count_prefix.is_some() {
+                        Some(Binding::Sequence(vec![
+                            Binding::Select(Motion::End),
+                            Binding::Custom(Message::Vim(VimAction::ResetOperatorAndCount)),
+                        ]))
+                    } else {
+                        Some(Binding::Select(Motion::End))
+                    }
                 }
 
                 // Movement: Buffer boundaries
-                Some('g') => {
-                    vim.count_prefix = None;
-                    Some(Binding::Custom(Message::Vim(VimAction::VisualGoToTop)))
-                }
+                Some('g') => Some(Binding::Custom(Message::Vim(VimAction::VisualGoToTop))),
                 Some('G') if modifiers.shift() => {
-                    vim.count_prefix = None;
                     Some(Binding::Custom(Message::Vim(VimAction::VisualGoToBottom)))
                 }
 
                 // Copy (Yank) selected text
-                Some('y') | Some('Y') => {
-                    vim.reset_operator_and_count();
-                    vim.mode = VimMode::Normal;
-                    vim.last_yank_is_line = is_line;
-                    Some(Binding::Sequence(vec![
-                        Binding::Copy,
-                        Binding::Custom(Message::Vim(VimAction::SetMode(VimMode::Normal))),
-                    ]))
-                }
+                Some('y') | Some('Y') => Some(Binding::Sequence(vec![
+                    Binding::Copy,
+                    Binding::Custom(Message::Vim(VimAction::VisualYank { is_line })),
+                ])),
 
                 // Delete selected text
-                Some('d') | Some('D') | Some('x') | Some('X') => {
-                    vim.reset_operator_and_count();
-                    vim.mode = VimMode::Normal;
-                    Some(Binding::Sequence(vec![
-                        Binding::Delete,
-                        Binding::Custom(Message::Vim(VimAction::SetMode(VimMode::Normal))),
-                    ]))
-                }
+                Some('d') | Some('D') | Some('x') | Some('X') => Some(Binding::Sequence(vec![
+                    Binding::Delete,
+                    Binding::Custom(Message::Vim(VimAction::SetMode(VimMode::Normal))),
+                ])),
 
                 // Paste (Replace selection with clipboard text)
-                Some('p') | Some('P') => {
-                    vim.reset_operator_and_count();
-                    vim.mode = VimMode::Normal;
-                    Some(Binding::Sequence(vec![
-                        Binding::Paste,
-                        Binding::Custom(Message::Vim(VimAction::SetMode(VimMode::Normal))),
-                    ]))
-                }
+                Some('p') | Some('P') => Some(Binding::Sequence(vec![
+                    Binding::Paste,
+                    Binding::Custom(Message::Vim(VimAction::SetMode(VimMode::Normal))),
+                ])),
 
                 // Toggle back to Normal mode on 'v' or 'V'
                 Some('v') | Some('V') => {
-                    vim.reset_operator_and_count();
-                    vim.mode = VimMode::Normal;
                     Some(Binding::Custom(Message::Vim(VimAction::Escape)))
                 }
 
                 // Consume any other character key so NO letters are inserted in Visual mode
                 _ => {
-                    vim.reset_operator_and_count();
-                    Some(Binding::Sequence(vec![]))
+                    if vim.count_prefix.is_some() {
+                        Some(Binding::Custom(Message::Vim(
+                            VimAction::ResetOperatorAndCount,
+                        )))
+                    } else {
+                        Some(Binding::Sequence(vec![]))
+                    }
                 }
             }
         }
     }
 }
 
-fn repeat_motion(vim: &mut VimState, motion: Motion) -> Option<Binding<Message>> {
-    let count = vim.count_prefix.take().unwrap_or(1);
+fn repeat_motion(vim: &VimState, motion: Motion) -> Option<Binding<Message>> {
+    let count = vim.count_prefix.unwrap_or(1);
     if count <= 1 {
-        Some(Binding::Move(motion))
+        if vim.count_prefix.is_some() || vim.pending_operator.is_some() {
+            Some(Binding::Sequence(vec![
+                Binding::Move(motion),
+                Binding::Custom(Message::Vim(VimAction::ResetOperatorAndCount)),
+            ]))
+        } else {
+            Some(Binding::Move(motion))
+        }
     } else {
-        Some(Binding::Sequence(vec![Binding::Move(motion); count]))
+        let mut seq = vec![Binding::Move(motion); count];
+        seq.push(Binding::Custom(Message::Vim(
+            VimAction::ResetOperatorAndCount,
+        )));
+        Some(Binding::Sequence(seq))
     }
 }
 
 fn repeat_motion_lines(
-    vim: &mut VimState,
+    vim: &VimState,
     motion: Motion,
     default_lines: usize,
 ) -> Option<Binding<Message>> {
-    let count = vim.count_prefix.take().unwrap_or(1);
+    let count = vim.count_prefix.unwrap_or(1);
     let total = count * default_lines;
-    Some(Binding::Sequence(vec![Binding::Move(motion); total]))
+    if vim.count_prefix.is_some() || vim.pending_operator.is_some() {
+        let mut seq = vec![Binding::Move(motion); total];
+        seq.push(Binding::Custom(Message::Vim(
+            VimAction::ResetOperatorAndCount,
+        )));
+        Some(Binding::Sequence(seq))
+    } else {
+        Some(Binding::Sequence(vec![Binding::Move(motion); total]))
+    }
 }
 
-fn repeat_select(vim: &mut VimState, motion: Motion) -> Option<Binding<Message>> {
-    let count = vim.count_prefix.take().unwrap_or(1);
+fn repeat_select(vim: &VimState, motion: Motion) -> Option<Binding<Message>> {
+    let count = vim.count_prefix.unwrap_or(1);
     if count <= 1 {
-        Some(Binding::Select(motion))
+        if vim.count_prefix.is_some() || vim.pending_operator.is_some() {
+            Some(Binding::Sequence(vec![
+                Binding::Select(motion),
+                Binding::Custom(Message::Vim(VimAction::ResetOperatorAndCount)),
+            ]))
+        } else {
+            Some(Binding::Select(motion))
+        }
     } else {
-        Some(Binding::Sequence(vec![Binding::Select(motion); count]))
+        let mut seq = vec![Binding::Select(motion); count];
+        seq.push(Binding::Custom(Message::Vim(
+            VimAction::ResetOperatorAndCount,
+        )));
+        Some(Binding::Sequence(seq))
     }
 }
 
 fn repeat_select_lines(
-    vim: &mut VimState,
+    vim: &VimState,
     motion: Motion,
     default_lines: usize,
 ) -> Option<Binding<Message>> {
-    let count = vim.count_prefix.take().unwrap_or(1);
+    let count = vim.count_prefix.unwrap_or(1);
     let total = count * default_lines;
-    Some(Binding::Sequence(vec![Binding::Select(motion); total]))
+    if vim.count_prefix.is_some() || vim.pending_operator.is_some() {
+        let mut seq = vec![Binding::Select(motion); total];
+        seq.push(Binding::Custom(Message::Vim(
+            VimAction::ResetOperatorAndCount,
+        )));
+        Some(Binding::Sequence(seq))
+    } else {
+        Some(Binding::Sequence(vec![Binding::Select(motion); total]))
+    }
 }
 
 #[cfg(test)]
@@ -513,7 +575,9 @@ mod tests {
         KeyPress {
             key: key.clone(),
             modified_key: key,
-            physical_key: keyboard::key::Physical::Unidentified(keyboard::key::NativeCode::Unidentified),
+            physical_key: keyboard::key::Physical::Unidentified(
+                keyboard::key::NativeCode::Unidentified,
+            ),
             modifiers,
             text: None,
             status: Status::Focused { is_hovered: true },
@@ -522,89 +586,138 @@ mod tests {
 
     #[test]
     fn test_normal_mode_motions() {
-        let mut vim = VimState::default();
+        let vim = VimState::default();
         let kp = make_key_press(Key::Character("j".into()), Modifiers::default());
-        let res = handle_vim_key_press(&mut vim, &kp);
+        let res = handle_vim_key_press(&vim, &kp);
         assert!(matches!(res, Some(Binding::Move(Motion::Down))));
     }
 
     #[test]
     fn test_count_prefix_motion() {
-        let mut vim = VimState::default();
+        let vim = VimState::default();
         let kp5 = make_key_press(Key::Character("5".into()), Modifiers::default());
-        let _ = handle_vim_key_press(&mut vim, &kp5);
-        assert_eq!(vim.count_prefix, Some(5));
+        let res1 = handle_vim_key_press(&vim, &kp5);
+        assert!(matches!(
+            res1,
+            Some(Binding::Custom(Message::Vim(VimAction::SetCountPrefix(Some(5)))))
+        ));
 
+        let vim_with_count = VimState {
+            count_prefix: Some(5),
+            ..Default::default()
+        };
         let kpj = make_key_press(Key::Character("j".into()), Modifiers::default());
-        let res = handle_vim_key_press(&mut vim, &kpj);
-        if let Some(Binding::Sequence(seq)) = res {
-            assert_eq!(seq.len(), 5);
+        let res2 = handle_vim_key_press(&vim_with_count, &kpj);
+        if let Some(Binding::Sequence(seq)) = res2 {
+            assert_eq!(seq.len(), 6);
             assert!(matches!(seq[0], Binding::Move(Motion::Down)));
+            assert!(matches!(
+                seq[5],
+                Binding::Custom(Message::Vim(VimAction::ResetOperatorAndCount))
+            ));
         } else {
-            panic!("Expected sequence of 5 moves");
+            panic!("Expected sequence of 5 moves + reset");
         }
-        assert_eq!(vim.count_prefix, None);
     }
 
     #[test]
     fn test_mode_transitions() {
-        let mut vim = VimState::default();
+        let vim = VimState::default();
         let kpi = make_key_press(Key::Character("i".into()), Modifiers::default());
-        let _ = handle_vim_key_press(&mut vim, &kpi);
-        assert_eq!(vim.mode, VimMode::Insert);
+        let res = handle_vim_key_press(&vim, &kpi);
+        assert!(matches!(
+            res,
+            Some(Binding::Custom(Message::Vim(VimAction::SetMode(
+                VimMode::Insert
+            ))))
+        ));
 
+        let vim_insert = VimState {
+            mode: VimMode::Insert,
+            ..Default::default()
+        };
         let kpesc = make_key_press(Key::Named(Named::Escape), Modifiers::default());
-        let _ = handle_vim_key_press(&mut vim, &kpesc);
-        assert_eq!(vim.mode, VimMode::Normal);
+        let res_esc = handle_vim_key_press(&vim_insert, &kpesc);
+        assert!(matches!(res_esc, Some(Binding::Sequence(_))));
     }
 
     #[test]
     fn test_visual_mode_yank() {
-        let mut vim = VimState::default();
-        vim.mode = VimMode::Visual;
+        let vim = VimState {
+            mode: VimMode::Visual,
+            ..Default::default()
+        };
         let kpy = make_key_press(Key::Character("y".into()), Modifiers::default());
-        let res = handle_vim_key_press(&mut vim, &kpy);
-        assert_eq!(vim.mode, VimMode::Normal);
-        assert!(matches!(res, Some(Binding::Sequence(_))));
+        let res = handle_vim_key_press(&vim, &kpy);
+        if let Some(Binding::Sequence(seq)) = res {
+            assert_eq!(seq.len(), 2);
+            assert!(matches!(seq[0], Binding::Copy));
+            assert!(matches!(
+                seq[1],
+                Binding::Custom(Message::Vim(VimAction::VisualYank { is_line: false }))
+            ));
+        } else {
+            panic!("Expected sequence of Copy + VisualYank");
+        }
     }
 
     #[test]
     fn test_normal_mode_dd_deletes_line() {
-        let mut vim = VimState::default();
+        let vim = VimState::default();
         let kpd = make_key_press(Key::Character("d".into()), Modifiers::default());
-        let res1 = handle_vim_key_press(&mut vim, &kpd);
-        assert!(matches!(res1, Some(Binding::Sequence(seq)) if seq.is_empty()));
-        assert_eq!(vim.pending_operator, Some(VimPendingOperator::D));
+        let res1 = handle_vim_key_press(&vim, &kpd);
+        assert!(matches!(
+            res1,
+            Some(Binding::Custom(Message::Vim(
+                VimAction::SetPendingOperator(Some(VimPendingOperator::D))
+            )))
+        ));
 
-        let res2 = handle_vim_key_press(&mut vim, &kpd);
-        assert!(matches!(res2, Some(Binding::Custom(Message::Vim(VimAction::DeleteLine)))));
-        assert_eq!(vim.pending_operator, None);
+        let vim_pending = VimState {
+            pending_operator: Some(VimPendingOperator::D),
+            ..Default::default()
+        };
+        let res2 = handle_vim_key_press(&vim_pending, &kpd);
+        assert!(matches!(
+            res2,
+            Some(Binding::Custom(Message::Vim(VimAction::DeleteLine)))
+        ));
     }
 
     #[test]
     fn test_normal_mode_unhandled_letters_consumed() {
-        let mut vim = VimState::default();
+        let vim = VimState::default();
         let kpz = make_key_press(Key::Character("z".into()), Modifiers::default());
-        let res = handle_vim_key_press(&mut vim, &kpz);
+        let res = handle_vim_key_press(&vim, &kpz);
         // Unhandled letters must return an empty sequence to consume the key without inserting text
         assert!(matches!(res, Some(Binding::Sequence(seq)) if seq.is_empty()));
     }
 
     #[test]
     fn test_visual_mode_delete() {
-        let mut vim = VimState::default();
-        vim.mode = VimMode::Visual;
+        let vim = VimState {
+            mode: VimMode::Visual,
+            ..Default::default()
+        };
         let kpd = make_key_press(Key::Character("d".into()), Modifiers::default());
-        let res = handle_vim_key_press(&mut vim, &kpd);
-        assert_eq!(vim.mode, VimMode::Normal);
-        assert!(matches!(res, Some(Binding::Sequence(_))));
+        let res = handle_vim_key_press(&vim, &kpd);
+        if let Some(Binding::Sequence(seq)) = res {
+            assert_eq!(seq.len(), 2);
+            assert!(matches!(seq[0], Binding::Delete));
+            assert!(matches!(
+                seq[1],
+                Binding::Custom(Message::Vim(VimAction::SetMode(VimMode::Normal)))
+            ));
+        } else {
+            panic!("Expected sequence of Delete + SetMode");
+        }
     }
 
     #[test]
     fn test_ctrl_u_ctrl_d_page_motions() {
-        let mut vim = VimState::default();
+        let vim = VimState::default();
         let kpd = make_key_press(Key::Character("d".into()), Modifiers::CTRL);
-        let res = handle_vim_key_press(&mut vim, &kpd);
+        let res = handle_vim_key_press(&vim, &kpd);
         if let Some(Binding::Sequence(seq)) = res {
             assert_eq!(seq.len(), 15);
             assert!(matches!(seq[0], Binding::Move(Motion::Down)));
@@ -613,12 +726,98 @@ mod tests {
         }
 
         let kpu = make_key_press(Key::Character("u".into()), Modifiers::CTRL);
-        let res = handle_vim_key_press(&mut vim, &kpu);
+        let res = handle_vim_key_press(&vim, &kpu);
         if let Some(Binding::Sequence(seq)) = res {
             assert_eq!(seq.len(), 15);
             assert!(matches!(seq[0], Binding::Move(Motion::Up)));
         } else {
             panic!("Expected sequence of 15 moves up");
+        }
+    }
+
+    #[test]
+    fn test_normal_mode_gg_goto_top() {
+        let vim = VimState::default();
+        let kpg = make_key_press(Key::Character("g".into()), Modifiers::default());
+        let res1 = handle_vim_key_press(&vim, &kpg);
+        assert!(matches!(
+            res1,
+            Some(Binding::Custom(Message::Vim(
+                VimAction::SetPendingOperator(Some(VimPendingOperator::G))
+            )))
+        ));
+
+        let vim_pending = VimState {
+            pending_operator: Some(VimPendingOperator::G),
+            ..Default::default()
+        };
+        let res2 = handle_vim_key_press(&vim_pending, &kpg);
+        assert!(matches!(
+            res2,
+            Some(Binding::Custom(Message::Vim(VimAction::GoToTop)))
+        ));
+    }
+
+    #[test]
+    fn test_normal_mode_yy_yank_line() {
+        let vim = VimState::default();
+        let kpy = make_key_press(Key::Character("y".into()), Modifiers::default());
+        let res1 = handle_vim_key_press(&vim, &kpy);
+        assert!(matches!(
+            res1,
+            Some(Binding::Custom(Message::Vim(
+                VimAction::SetPendingOperator(Some(VimPendingOperator::Y))
+            )))
+        ));
+
+        let vim_pending = VimState {
+            pending_operator: Some(VimPendingOperator::Y),
+            ..Default::default()
+        };
+        let res2 = handle_vim_key_press(&vim_pending, &kpy);
+        assert!(matches!(
+            res2,
+            Some(Binding::Custom(Message::Vim(VimAction::YankLine)))
+        ));
+    }
+
+    #[test]
+    fn test_normal_mode_zero_vs_count_prefix() {
+        let vim = VimState::default();
+        let kp0 = make_key_press(Key::Character("0".into()), Modifiers::default());
+        let res0 = handle_vim_key_press(&vim, &kp0);
+        // '0' alone moves to Home
+        assert!(matches!(res0, Some(Binding::Move(Motion::Home))));
+
+        // '1' followed by '0' sets count to 10
+        let vim_with_1 = VimState {
+            count_prefix: Some(1),
+            ..Default::default()
+        };
+        let res10 = handle_vim_key_press(&vim_with_1, &kp0);
+        assert!(matches!(
+            res10,
+            Some(Binding::Custom(Message::Vim(VimAction::SetCountPrefix(Some(10)))))
+        ));
+    }
+
+    #[test]
+    fn test_pending_operator_cancelled_by_motion() {
+        let vim = VimState {
+            pending_operator: Some(VimPendingOperator::D),
+            ..Default::default()
+        };
+        let kpj = make_key_press(Key::Character("j".into()), Modifiers::default());
+        let res = handle_vim_key_press(&vim, &kpj);
+        if let Some(Binding::Sequence(seq)) = res {
+            assert_eq!(seq.len(), 2);
+            assert!(matches!(seq[0], Binding::Move(Motion::Down)));
+            assert!(matches!(
+                seq[1],
+                Binding::Custom(Message::Vim(VimAction::ResetOperatorAndCount))
+            ));
+        } else {
+            panic!("Expected sequence of Move + ResetOperatorAndCount");
         }
     }
 }

--- a/src/app/update/config.rs
+++ b/src/app/update/config.rs
@@ -86,6 +86,16 @@ impl AppModel {
                 }
                 Ok(())
             }),
+            ConfigInput::VimMode(state) => self.apply_config(|config, handler| {
+                if let Some(h) = handler {
+                    config
+                        .set_vim_mode(h, state)
+                        .map_err(|e| e.to_string())?;
+                } else {
+                    config.vim_mode = state;
+                }
+                Ok(())
+            }),
             ConfigInput::GotenbergUrlInput(state) => self.apply_config(|config, handler| {
                 if let Some(h) = handler {
                     config

--- a/src/app/update/editor.rs
+++ b/src/app/update/editor.rs
@@ -1,15 +1,15 @@
-// SPDX-License-Identifier: GPL-3.0
-
 use crate::app::core::editor::{EditorSearchState, EditorState};
 use crate::app::core::utils::search::SearchAction;
 use crate::app::core::utils::{self};
+use crate::app::core::vim::VimMode;
 use crate::app::{
-    AppModel, Message, State, editor_scrollable_id, preview_scrollable_id, search_input_id,
+    AppModel, Message, State, VimAction, editor_scrollable_id, preview_scrollable_id, search_input_id,
     text_editor_id,
 };
-use crate::config::BoolState;
+use crate::config::{BoolState, ConfigInput};
 use cosmic::iced::widget::scrollable::scroll_to;
 use cosmic::prelude::*;
+use cosmic::widget::text_editor::{Cursor, Position};
 use widgets::text_editor;
 
 impl AppModel {
@@ -280,6 +280,237 @@ impl AppModel {
             }
 
             SearchAction::FocusSearchField => cosmic::widget::text_input::focus(search_input_id()),
+        }
+    }
+
+    pub fn handle_toggle_vim_mode(&mut self) -> Task<cosmic::Action<Message>> {
+        let new_state = match self.config.vim_mode {
+            BoolState::Yes => BoolState::No,
+            BoolState::No => BoolState::Yes,
+        };
+        self.handle_config_input(ConfigInput::VimMode(new_state))
+    }
+
+    pub fn handle_vim_action(&mut self, action: VimAction) -> Task<cosmic::Action<Message>> {
+        let State::Ready {
+            editor, preview, ..
+        } = &mut self.state
+        else {
+            return Task::none();
+        };
+
+        let sync_preview = self.config.scrollbar_sync == BoolState::Yes;
+
+        match action {
+            VimAction::SetMode(mode) => {
+                editor.vim.mode = mode;
+                editor.vim.reset_operator_and_count();
+                if mode == VimMode::Normal {
+                    let pos = editor.content.cursor().position;
+                    editor.content.move_to(Cursor {
+                        position: pos,
+                        selection: None,
+                    });
+                }
+                Task::none()
+            }
+            VimAction::Escape => {
+                editor.vim.mode = VimMode::Normal;
+                editor.vim.reset_operator_and_count();
+                let pos = editor.content.cursor().position;
+                editor.content.move_to(Cursor {
+                    position: pos,
+                    selection: None,
+                });
+                Task::none()
+            }
+            VimAction::GoToTop => {
+                editor.content.move_to(Cursor {
+                    position: Position { line: 0, column: 0 },
+                    selection: None,
+                });
+                ensure_cursor_visible(editor, sync_preview)
+            }
+            VimAction::GoToBottom => {
+                let last_line = editor.content.line_count().saturating_sub(1);
+                editor.content.move_to(Cursor {
+                    position: Position {
+                        line: last_line,
+                        column: 0,
+                    },
+                    selection: None,
+                });
+                ensure_cursor_visible(editor, sync_preview)
+            }
+            VimAction::VisualGoToTop => {
+                let anchor = editor
+                    .content
+                    .cursor()
+                    .selection
+                    .unwrap_or(editor.content.cursor().position);
+                editor.content.move_to(Cursor {
+                    position: Position { line: 0, column: 0 },
+                    selection: Some(anchor),
+                });
+                ensure_cursor_visible(editor, sync_preview)
+            }
+            VimAction::VisualGoToBottom => {
+                let anchor = editor
+                    .content
+                    .cursor()
+                    .selection
+                    .unwrap_or(editor.content.cursor().position);
+                let last_line = editor.content.line_count().saturating_sub(1);
+                let last_col = editor
+                    .content
+                    .line(last_line)
+                    .map(|l| l.text.chars().count())
+                    .unwrap_or(0);
+                editor.content.move_to(Cursor {
+                    position: Position {
+                        line: last_line,
+                        column: last_col,
+                    },
+                    selection: Some(anchor),
+                });
+                ensure_cursor_visible(editor, sync_preview)
+            }
+            VimAction::YankLine => {
+                let line_idx = editor.content.cursor().position.line;
+                if let Some(line) = editor.content.line(line_idx) {
+                    let text_to_copy = format!("{}\n", line.text);
+                    editor.vim.last_yank_is_line = true;
+                    editor.vim.mode = VimMode::Normal;
+                    editor.vim.reset_operator_and_count();
+                    self.handle_copy_to_clipboard(text_to_copy)
+                } else {
+                    Task::none()
+                }
+            }
+            VimAction::DeleteLine => {
+                let cursor_line = editor.content.cursor().position.line;
+                let total_lines = editor.content.line_count();
+
+                if let Some(line) = editor.content.line(cursor_line) {
+                    let line_text = format!("{}\n", line.text);
+                    editor.vim.last_yank_is_line = true;
+                    if let Ok(mut clipboard) = arboard::Clipboard::new() {
+                        let _ = clipboard.set_text(line_text);
+                    }
+                }
+
+                let cursor_before = editor.content.cursor().position;
+
+                if total_lines <= 1 {
+                    editor.content.perform(text_editor::Action::SelectAll);
+                    editor.content.perform(text_editor::Action::Edit(text_editor::Edit::Delete));
+                } else if cursor_line + 1 < total_lines {
+                    editor.content.move_to(Cursor {
+                        position: Position {
+                            line: cursor_line,
+                            column: 0,
+                        },
+                        selection: None,
+                    });
+                    editor.content.move_to(Cursor {
+                        position: Position {
+                            line: cursor_line + 1,
+                            column: 0,
+                        },
+                        selection: Some(Position {
+                            line: cursor_line,
+                            column: 0,
+                        }),
+                    });
+                    editor.content.perform(text_editor::Action::Edit(text_editor::Edit::Delete));
+                } else {
+                    let prev_line = cursor_line - 1;
+                    let prev_len = editor
+                        .content
+                        .line(prev_line)
+                        .map(|l| l.text.chars().count())
+                        .unwrap_or(0);
+                    let cur_len = editor
+                        .content
+                        .line(cursor_line)
+                        .map(|l| l.text.chars().count())
+                        .unwrap_or(0);
+                    editor.content.move_to(Cursor {
+                        position: Position {
+                            line: cursor_line,
+                            column: cur_len,
+                        },
+                        selection: Some(Position {
+                            line: prev_line,
+                            column: prev_len,
+                        }),
+                    });
+                    editor.content.perform(text_editor::Action::Edit(text_editor::Edit::Delete));
+                }
+
+                editor.is_dirty = true;
+                editor.push_history((cursor_before.line, cursor_before.column));
+                preview.update_content(editor.content.text().as_ref());
+                ensure_cursor_visible(editor, sync_preview)
+            }
+            VimAction::Paste { before } => {
+                if let Ok(mut clipboard) = arboard::Clipboard::new() {
+                    if let Ok(text) = clipboard.get_text() {
+                        if text.is_empty() {
+                            return Task::none();
+                        }
+                        let is_line = text.ends_with('\n');
+                        let cursor_before = editor.content.cursor().position;
+
+                        if is_line {
+                            if before {
+                                editor
+                                    .content
+                                    .perform(text_editor::Action::Move(text_editor::Motion::Home));
+                                editor
+                                    .content
+                                    .perform(text_editor::Action::Edit(text_editor::Edit::Paste(
+                                        std::sync::Arc::new(text),
+                                    )));
+                            } else {
+                                editor
+                                    .content
+                                    .perform(text_editor::Action::Move(text_editor::Motion::End));
+                                editor
+                                    .content
+                                    .perform(text_editor::Action::Edit(text_editor::Edit::Enter));
+                                editor
+                                    .content
+                                    .perform(text_editor::Action::Edit(text_editor::Edit::Paste(
+                                        std::sync::Arc::new(
+                                            text.trim_end_matches('\n').to_string(),
+                                        ),
+                                    )));
+                            }
+                        } else {
+                            if !before {
+                                editor.content.perform(text_editor::Action::Move(
+                                    text_editor::Motion::Right,
+                                ));
+                            }
+                            editor
+                                .content
+                                .perform(text_editor::Action::Edit(text_editor::Edit::Paste(
+                                    std::sync::Arc::new(text),
+                                )));
+                        }
+
+                        editor.is_dirty = true;
+                        editor.push_history((cursor_before.line, cursor_before.column));
+                        preview.update_content(editor.content.text().as_ref());
+                        ensure_cursor_visible(editor, sync_preview)
+                    } else {
+                        Task::none()
+                    }
+                } else {
+                    Task::none()
+                }
+            }
         }
     }
 }

--- a/src/app/update/editor.rs
+++ b/src/app/update/editor.rs
@@ -32,26 +32,25 @@ impl AppModel {
             editor.content.perform(action);
         }
 
-        preview.update_content(editor.content.text().as_ref());
-
         if was_edit {
+            preview.update_content(editor.content.text().as_ref());
             editor.is_dirty = true;
             editor.push_history((cursor_before.line, cursor_before.column));
         }
 
         let sync_preview = self.config.scrollbar_sync == BoolState::Yes;
-        let cursor_task = if was_edit {
-            ensure_cursor_visible(editor, sync_preview)
-        } else {
-            Task::none()
-        };
+        let cursor_task = ensure_cursor_visible(editor, sync_preview);
 
-        utils::images::download_images(
-            &mut preview.markstate,
-            &mut preview.images_in_progress,
-            &editor.path,
-        )
-        .chain(cursor_task)
+        if was_edit {
+            utils::images::download_images(
+                &mut preview.markstate,
+                &mut preview.images_in_progress,
+                &editor.path,
+            )
+            .chain(cursor_task)
+        } else {
+            cursor_task
+        }
     }
 
     pub fn handle_apply_formatting(
@@ -528,22 +527,32 @@ fn ensure_cursor_visible(
     let cursor_line = editor.content.cursor().position.line;
     let content_height = editor_vp.content_bounds().height;
     let viewport_height = editor_vp.bounds().height;
+    let max_scroll = (content_height - viewport_height).max(0.0);
+
+    if max_scroll == 0.0 {
+        return Task::none();
+    }
+
     let line_height = content_height / total_lines as f32;
     let cursor_top = cursor_line as f32 * line_height;
     let cursor_bottom = cursor_top + line_height;
     let scroll_y = editor_vp.absolute_offset().y;
-    let padding = line_height * 3.0;
+    let padding = (line_height * 3.0).min(viewport_height * 0.3);
 
     let new_editor_y = if cursor_top < scroll_y + padding {
         // cursor above visible area
         (cursor_top - padding).max(0.0)
     } else if cursor_bottom > scroll_y + viewport_height - padding {
         // cursor below visible area
-        cursor_bottom + padding - viewport_height
+        (cursor_bottom + padding - viewport_height).min(max_scroll)
     } else {
         // already visible, nothing to do
         return Task::none();
     };
+
+    if (new_editor_y - scroll_y).abs() < 1.0 {
+        return Task::none();
+    }
 
     // scroll editor, marking it as programmatic so it isn't re-synced via on_scroll
     editor.scroll.pending_editor_scrolls += 1;
@@ -554,12 +563,7 @@ fn ensure_cursor_visible(
     if let Some(preview_vp) = editor.scroll.last_preview_viewport
         && sync_preview
     {
-        let editor_scrollable = (content_height - viewport_height).max(0.0);
-        let rel = if editor_scrollable > 0.0 {
-            new_editor_y / editor_scrollable
-        } else {
-            0.0
-        };
+        let rel = new_editor_y / max_scroll;
         let preview_scrollable =
             (preview_vp.content_bounds().height - preview_vp.bounds().height).max(0.0);
         let new_preview_y = (rel * preview_scrollable).max(0.0);

--- a/src/app/update/editor.rs
+++ b/src/app/update/editor.rs
@@ -313,6 +313,29 @@ impl AppModel {
                 }
                 Task::none()
             }
+            VimAction::SetPendingOperator(op) => {
+                editor.vim.pending_operator = op;
+                Task::none()
+            }
+            VimAction::SetCountPrefix(count) => {
+                editor.vim.count_prefix = count;
+                Task::none()
+            }
+            VimAction::ResetOperatorAndCount => {
+                editor.vim.reset_operator_and_count();
+                Task::none()
+            }
+            VimAction::VisualYank { is_line } => {
+                editor.vim.mode = VimMode::Normal;
+                editor.vim.last_yank_is_line = is_line;
+                editor.vim.reset_operator_and_count();
+                let pos = editor.content.cursor().position;
+                editor.content.move_to(Cursor {
+                    position: pos,
+                    selection: None,
+                });
+                Task::none()
+            }
             VimAction::Escape => {
                 editor.vim.mode = VimMode::Normal;
                 editor.vim.reset_operator_and_count();
@@ -324,6 +347,7 @@ impl AppModel {
                 Task::none()
             }
             VimAction::GoToTop => {
+                editor.vim.reset_operator_and_count();
                 editor.content.move_to(Cursor {
                     position: Position { line: 0, column: 0 },
                     selection: None,
@@ -331,6 +355,7 @@ impl AppModel {
                 ensure_cursor_visible(editor, sync_preview)
             }
             VimAction::GoToBottom => {
+                editor.vim.reset_operator_and_count();
                 let last_line = editor.content.line_count().saturating_sub(1);
                 editor.content.move_to(Cursor {
                     position: Position {
@@ -342,6 +367,7 @@ impl AppModel {
                 ensure_cursor_visible(editor, sync_preview)
             }
             VimAction::VisualGoToTop => {
+                editor.vim.reset_operator_and_count();
                 let anchor = editor
                     .content
                     .cursor()
@@ -354,6 +380,7 @@ impl AppModel {
                 ensure_cursor_visible(editor, sync_preview)
             }
             VimAction::VisualGoToBottom => {
+                editor.vim.reset_operator_and_count();
                 let anchor = editor
                     .content
                     .cursor()
@@ -375,18 +402,19 @@ impl AppModel {
                 ensure_cursor_visible(editor, sync_preview)
             }
             VimAction::YankLine => {
+                editor.vim.reset_operator_and_count();
                 let line_idx = editor.content.cursor().position.line;
                 if let Some(line) = editor.content.line(line_idx) {
                     let text_to_copy = format!("{}\n", line.text);
                     editor.vim.last_yank_is_line = true;
                     editor.vim.mode = VimMode::Normal;
-                    editor.vim.reset_operator_and_count();
                     self.handle_copy_to_clipboard(text_to_copy)
                 } else {
                     Task::none()
                 }
             }
             VimAction::DeleteLine => {
+                editor.vim.reset_operator_and_count();
                 let cursor_line = editor.content.cursor().position.line;
                 let total_lines = editor.content.line_count();
 
@@ -453,6 +481,7 @@ impl AppModel {
                 ensure_cursor_visible(editor, sync_preview)
             }
             VimAction::Paste { before } => {
+                editor.vim.reset_operator_and_count();
                 if let Ok(mut clipboard) = arboard::Clipboard::new() {
                     if let Ok(text) = clipboard.get_text() {
                         if text.is_empty() {

--- a/src/app/update/file.rs
+++ b/src/app/update/file.rs
@@ -4,6 +4,7 @@ use crate::app::core::editor::{EditorScrollState, EditorSearchState, EditorState
 use crate::app::core::history::HistoryState;
 use crate::app::core::preview::MarkdownPreview;
 use crate::app::core::utils::{self, CedillaToast};
+use crate::app::core::vim::VimState;
 use crate::app::{
     AppModel, Message, PreviewState, State, editor_scrollable_id, preview_scrollable_id,
 };
@@ -56,6 +57,7 @@ impl AppModel {
                 history: HistoryState::default(),
                 scroll: EditorScrollState::default(),
                 search: EditorSearchState::default(),
+                vim: VimState::default(),
                 ignore_next_external_change: false,
             },
             preview: MarkdownPreview {
@@ -87,6 +89,7 @@ impl AppModel {
                     ..EditorScrollState::default()
                 },
                 search: EditorSearchState::default(),
+                vim: VimState::default(),
                 ignore_next_external_change: false,
             },
             preview: MarkdownPreview {
@@ -150,6 +153,7 @@ impl AppModel {
                     ..EditorScrollState::default()
                 },
                 search: EditorSearchState::default(),
+                vim: VimState::default(),
                 ignore_next_external_change: false,
             },
             preview: MarkdownPreview {
@@ -265,6 +269,7 @@ impl AppModel {
                             ..EditorScrollState::default()
                         },
                         search: EditorSearchState::default(),
+                        vim: VimState::default(),
                         ignore_next_external_change: false,
                     },
                     preview: MarkdownPreview {

--- a/src/app/update/menu.rs
+++ b/src/app/update/menu.rs
@@ -48,6 +48,7 @@ impl AppModel {
             MenuAction::PasteImage => self.handle_paste_image(),
             MenuAction::Search => self.handle_search(utils::search::SearchAction::ToggleSearch),
             MenuAction::CloseCurrentDialog => self.handle_dialog_action(dialogs::DialogAction::DialogCancel),
+            MenuAction::ToggleVimMode => self.handle_toggle_vim_mode(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,6 +30,7 @@ pub struct CedillaConfig {
     pub light_highlighter_theme: CedillaHighlighterTheme,
     pub dark_highlighter_theme: CedillaHighlighterTheme,
     pub selected_font_family: Option<String>,
+    pub vim_mode: BoolState,
 }
 
 impl Default for CedillaConfig {
@@ -62,6 +63,7 @@ impl Default for CedillaConfig {
                 cosmic::iced::highlighter::Theme::Base16Ocean,
             ),
             selected_font_family: None,
+            vim_mode: BoolState::No,
         }
     }
 }
@@ -255,4 +257,6 @@ pub enum ConfigInput {
     UpdateFont(usize),
     /// Reset to the default font
     ResetFont,
+    /// Update if vim mode is enabled or not
+    VimMode(BoolState),
 }

--- a/widgets/src/text_editor.rs
+++ b/widgets/src/text_editor.rs
@@ -135,6 +135,7 @@ where
     ellipsize: Ellipsize,
     retain_focus_on_external_click: bool,
     is_code_block: bool,
+    block_cursor: bool,
     class: Theme::Class<'a>,
     key_binding: Option<Box<dyn Fn(KeyPress) -> Option<Binding<Message>> + 'a>>,
     on_edit: Option<Box<dyn Fn(Action) -> Message + 'a>>,
@@ -166,6 +167,7 @@ where
             ellipsize: Ellipsize::default(),
             retain_focus_on_external_click: false,
             is_code_block: false,
+            block_cursor: false,
             class: <Theme as Catalog>::default(),
             key_binding: None,
             on_edit: None,
@@ -320,6 +322,7 @@ where
             ellipsize: self.ellipsize,
             retain_focus_on_external_click: self.retain_focus_on_external_click,
             is_code_block: self.is_code_block,
+            block_cursor: self.block_cursor,
             class: self.class,
             key_binding: self.key_binding,
             on_edit: self.on_edit,
@@ -347,6 +350,13 @@ where
         Theme::Class<'a>: From<StyleFn<'a, Theme>>,
     {
         self.class = (Box::new(style) as StyleFn<'a, Theme>).into();
+        self
+    }
+
+    /// Sets whether to render a block cursor.
+    #[must_use]
+    pub fn block_cursor(mut self, block_cursor: bool) -> Self {
+        self.block_cursor = block_cursor;
         self
     }
 
@@ -1052,14 +1062,19 @@ where
                 if let Some(focus) = state.focus.as_ref()
                     && focus.is_cursor_visible()
                 {
+                    let font_size = self.text_size.unwrap_or_else(|| renderer.default_size());
+                    let cursor_width = if self.block_cursor {
+                        (font_size.0 * 0.6).max(8.0)
+                    } else {
+                        1.0
+                    };
+
                     let cursor = Rectangle::new(
                         position + translation,
                         Size::new(
-                            1.0,
+                            cursor_width,
                             self.line_height
-                                .to_absolute(
-                                    self.text_size.unwrap_or_else(|| renderer.default_size()),
-                                )
+                                .to_absolute(font_size)
                                 .into(),
                         ),
                     );
@@ -1070,7 +1085,14 @@ where
                                 bounds: clipped_cursor,
                                 ..renderer::Quad::default()
                             },
-                            style.value,
+                            if self.block_cursor {
+                                Color {
+                                    a: 0.5,
+                                    ..style.value
+                                }
+                            } else {
+                                style.value
+                            },
                         );
                     }
                 }

--- a/widgets/src/text_editor.rs
+++ b/widgets/src/text_editor.rs
@@ -136,6 +136,7 @@ where
     retain_focus_on_external_click: bool,
     is_code_block: bool,
     block_cursor: bool,
+    enable_input_method: bool,
     class: Theme::Class<'a>,
     key_binding: Option<Box<dyn Fn(KeyPress) -> Option<Binding<Message>> + 'a>>,
     on_edit: Option<Box<dyn Fn(Action) -> Message + 'a>>,
@@ -168,6 +169,7 @@ where
             retain_focus_on_external_click: false,
             is_code_block: false,
             block_cursor: false,
+            enable_input_method: true,
             class: <Theme as Catalog>::default(),
             key_binding: None,
             on_edit: None,
@@ -323,6 +325,7 @@ where
             retain_focus_on_external_click: self.retain_focus_on_external_click,
             is_code_block: self.is_code_block,
             block_cursor: self.block_cursor,
+            enable_input_method: self.enable_input_method,
             class: self.class,
             key_binding: self.key_binding,
             on_edit: self.on_edit,
@@ -360,6 +363,13 @@ where
         self
     }
 
+    /// Sets whether input method (IME) is enabled.
+    #[must_use]
+    pub fn enable_input_method(mut self, enable_input_method: bool) -> Self {
+        self.enable_input_method = enable_input_method;
+        self
+    }
+
     /// Sets the style class of the [`TextEditor`].
     #[must_use]
     pub fn class(mut self, class: impl Into<Theme::Class<'a>>) -> Self {
@@ -373,6 +383,10 @@ where
         renderer: &Renderer,
         layout: Layout<'_>,
     ) -> InputMethod<&'b str> {
+        if !self.enable_input_method {
+            return InputMethod::Disabled;
+        }
+
         let Some(Focus {
             is_window_focused: true,
             ..
@@ -577,6 +591,7 @@ pub struct State<Highlighter: text::Highlighter> {
     highlighter: RefCell<Highlighter>,
     highlighter_settings: Highlighter::Settings,
     highlighter_format_address: usize,
+    last_input_method_enabled: Option<bool>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -650,6 +665,7 @@ where
             highlighter: RefCell::new(Highlighter::new(&self.highlighter_settings)),
             highlighter_settings: self.highlighter_settings.clone(),
             highlighter_format_address: self.highlighter_format as usize,
+            last_input_method_enabled: None,
         })
     }
 
@@ -775,6 +791,16 @@ where
             _ => {}
         }
 
+        if state.last_input_method_enabled != Some(self.enable_input_method) {
+            state.last_input_method_enabled = Some(self.enable_input_method);
+            if !self.enable_input_method {
+                state.preedit = None;
+                state.last_commit = None;
+            }
+            shell.request_input_method(&self.input_method(state, renderer, layout));
+            shell.request_redraw();
+        }
+
         if let Some(update) = Update::from_event(
             event,
             state,
@@ -783,6 +809,7 @@ where
             cursor,
             self.key_binding.as_deref(),
             self.retain_focus_on_external_click,
+            self.enable_input_method,
         ) {
             match update {
                 Update::Click(click) => {
@@ -1324,6 +1351,7 @@ enum Ime {
 }
 
 impl<Message> Update<Message> {
+    #[allow(clippy::too_many_arguments)]
     fn from_event<H: Highlighter>(
         event: &Event,
         state: &State<H>,
@@ -1332,6 +1360,7 @@ impl<Message> Update<Message> {
         cursor: mouse::Cursor,
         key_binding: Option<&dyn Fn(KeyPress) -> Option<Binding<Message>>>,
         retain_focus_on_external_click: bool,
+        enable_input_method: bool,
     ) -> Option<Self> {
         let binding = |binding| Some(Update::Binding(binding));
 
@@ -1386,21 +1415,64 @@ impl<Message> Update<Message> {
                 }
                 _ => None,
             },
-            Event::InputMethod(event) => match event {
-                input_method::Event::Opened | input_method::Event::Closed => Some(
-                    Update::InputMethod(Ime::Toggle(matches!(event, input_method::Event::Opened))),
-                ),
-                input_method::Event::Preedit(content, selection) if state.focus.is_some() => {
-                    Some(Update::InputMethod(Ime::Preedit {
-                        content: content.clone(),
-                        selection: selection.clone(),
-                    }))
+            Event::InputMethod(event) => {
+                if !enable_input_method {
+                    if let input_method::Event::Commit(content) = event
+                        && state.focus.is_some()
+                        && let Some(key_binding) = key_binding
+                    {
+                        let status = Status::Focused {
+                            is_hovered: cursor.is_over(bounds),
+                        };
+                        let mut bindings = Vec::new();
+                        for c in content.chars() {
+                            let mut modifiers = keyboard::Modifiers::default();
+                            if c.is_uppercase() {
+                                modifiers |= keyboard::Modifiers::SHIFT;
+                            }
+                            let s = c.to_string();
+                            let smol: SmolStr = s.into();
+                            let key_press = KeyPress {
+                                key: keyboard::Key::Character(smol.clone()),
+                                modified_key: keyboard::Key::Character(smol.clone()),
+                                physical_key: keyboard::key::Physical::Unidentified(
+                                    keyboard::key::NativeCode::Unidentified,
+                                ),
+                                modifiers,
+                                text: Some(smol),
+                                status,
+                            };
+                            if let Some(binding) = key_binding(key_press) {
+                                bindings.push(binding);
+                            }
+                        }
+                        if !bindings.is_empty() {
+                            return Some(Update::Binding(if bindings.len() == 1 {
+                                bindings.remove(0)
+                            } else {
+                                Binding::Sequence(bindings)
+                            }));
+                        }
+                    }
+                    None
+                } else {
+                    match event {
+                        input_method::Event::Opened | input_method::Event::Closed => Some(
+                            Update::InputMethod(Ime::Toggle(matches!(event, input_method::Event::Opened))),
+                        ),
+                        input_method::Event::Preedit(content, selection) if state.focus.is_some() => {
+                            Some(Update::InputMethod(Ime::Preedit {
+                                content: content.clone(),
+                                selection: selection.clone(),
+                            }))
+                        }
+                        input_method::Event::Commit(content) if state.focus.is_some() => {
+                            Some(Update::InputMethod(Ime::Commit(content.clone())))
+                        }
+                        _ => None,
+                    }
                 }
-                input_method::Event::Commit(content) if state.focus.is_some() => {
-                    Some(Update::InputMethod(Ime::Commit(content.clone())))
-                }
-                _ => None,
-            },
+            }
             Event::Keyboard(keyboard::Event::KeyPressed {
                 key,
                 modified_key,
@@ -1564,4 +1636,103 @@ pub(crate) fn convert_macos_shortcut(
     };
 
     Some(keyboard::Key::Named(key))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_enable_input_method_builder() {
+        let content = Content::with_text("hello");
+        let editor: TextEditor<'_, highlighter::PlainText, ()> = TextEditor::new(&content);
+        assert!(editor.enable_input_method);
+
+        let editor = editor.enable_input_method(false);
+        assert!(!editor.enable_input_method);
+
+        let highlighted = editor.highlight_with::<highlighter::PlainText>((), |_h, _t| {
+            highlighter::Format::default()
+        });
+        assert!(!highlighted.enable_input_method);
+
+        let re_enabled = highlighted.enable_input_method(true);
+        assert!(re_enabled.enable_input_method);
+    }
+
+    #[test]
+    fn test_from_event_input_method_commit_when_disabled() {
+        let state: State<highlighter::PlainText> = State {
+            focus: Some(Focus::now()),
+            preedit: None,
+            last_click: None,
+            drag_click: None,
+            partial_scroll: 0.0,
+            last_commit: None,
+            last_theme: RefCell::default(),
+            highlighter: RefCell::new(highlighter::PlainText),
+            highlighter_settings: (),
+            highlighter_format_address: 0,
+            last_input_method_enabled: None,
+        };
+
+        let commit_event = Event::InputMethod(input_method::Event::Commit("i".to_string()));
+        let key_binding = |kp: KeyPress| {
+            if let keyboard::Key::Character(c) = kp.key {
+                if c == "i" {
+                    return Some(Binding::Custom("enter_insert_mode"));
+                }
+            }
+            None
+        };
+
+        // When IME is disabled, Commit("i") should route through key_binding
+        let update = Update::from_event(
+            &commit_event,
+            &state,
+            Rectangle::default(),
+            Padding::default(),
+            mouse::Cursor::Unavailable,
+            Some(&key_binding),
+            false,
+            false, // enable_input_method = false
+        );
+
+        assert!(matches!(
+            update,
+            Some(Update::Binding(Binding::Custom("enter_insert_mode")))
+        ));
+
+        // When unhandled key commit arrives and IME is disabled, it should return None (never paste!)
+        let unhandled_event = Event::InputMethod(input_method::Event::Commit("x".to_string()));
+        let update_unhandled = Update::from_event(
+            &unhandled_event,
+            &state,
+            Rectangle::default(),
+            Padding::default(),
+            mouse::Cursor::Unavailable,
+            Some(&key_binding),
+            false,
+            false, // enable_input_method = false
+        );
+        assert!(update_unhandled.is_none());
+
+        // When IME is enabled, Commit("hello") should produce Update::InputMethod(Ime::Commit)
+        let normal_commit_event =
+            Event::InputMethod(input_method::Event::Commit("hello".to_string()));
+        let update_enabled = Update::from_event(
+            &normal_commit_event,
+            &state,
+            Rectangle::default(),
+            Padding::default(),
+            mouse::Cursor::Unavailable,
+            Some(&key_binding),
+            false,
+            true, // enable_input_method = true
+        );
+        assert!(matches!(
+            update_enabled,
+            Some(Update::InputMethod(Ime::Commit(text))) if text == "hello"
+        ));
+    }
 }


### PR DESCRIPTION
Hey, this PR adds a toggleable basic VIM mode to the editor. User is able to enter Normal, Insert and Visual modes. Yank, delete, paste and do all basic Vim movements. It is fully optional and user can turn it on or off in Edit menu